### PR TITLE
V2 frame editor pages

### DIFF
--- a/src/contexts/V2SearchDetailsProvider.js
+++ b/src/contexts/V2SearchDetailsProvider.js
@@ -14,6 +14,7 @@ export const V2SearchDetailsProvider = ({ children }) => {
     const [fineTuningFrame, setFineTuningFrame] = useState();
     const [localCids, setLocalCids] = useState();
     const [showObj, setShowObj] = useState();
+    const [selectedFrameIndex, setSelectedFrameIndex] = useState();
 
     useEffect(() => {
         if (pathname === '/') {
@@ -40,7 +41,9 @@ export const V2SearchDetailsProvider = ({ children }) => {
                 localCids,
                 setLocalCids,
                 showObj,
-                setShowObj
+                setShowObj,
+                selectedFrameIndex,
+                setSelectedFrameIndex
             }}
         >
             {children}

--- a/src/contexts/v2-search-context.js
+++ b/src/contexts/v2-search-context.js
@@ -14,6 +14,8 @@ export const V2SearchContext = createContext({
     localCids: null,
     setLocalCids: () => { console.log('setLocalCids was called with no provider available'); },
     showObj: null,
-    setShowObj: () => { console.log('setShowObj was called with no provider available'); }
+    setShowObj: () => { console.log('setShowObj was called with no provider available'); },
+    selectedFrameIndex: null,
+    setSelectedFrameIndex: () => { console.log('setSelectedFrameIndex was called with no provider available'); }
 });
 

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -643,8 +643,6 @@ export default function FramePage({ shows = [] }) {
       console.log(Math.floor(frames.length / 2))
       setSelectedFrameIndex(selectedFrameIndex || Math.floor(frames.length / 2))
       setDisplayImage(selectedFrameIndex ? frames[selectedFrameIndex] : frames[Math.floor(frames.length / 2)])
-    } else {
-      setSelectedFrameIndex()
     }
   }, [frames]);
 
@@ -711,7 +709,7 @@ export default function FramePage({ shows = [] }) {
               size="small"
               defaultValue={selectedFrameIndex || Math.floor(frames.length / 2)}
               min={0}
-              max={frames.length}
+              max={frames.length - 1}
               value={selectedFrameIndex}
               step={1}
               onChange={(e, newValue) => handleSliderChange(newValue)}
@@ -999,7 +997,7 @@ export default function FramePage({ shows = [] }) {
               size="medium"
               fullWidth
               variant="contained"
-              // to={`/editor/${fid}${getCurrentQueryString()}`}
+              to={`/v2/editor/${params?.cid}/${params?.subtitleIndex}`}
               component={RouterLink}
               sx={{ my: 2, backgroundColor: '#4CAF50', '&:hover': { backgroundColor: '#45a045' } }}
               startIcon={<Edit />}

--- a/src/sections/search/ipfs-search-bar.js
+++ b/src/sections/search/ipfs-search-bar.js
@@ -95,7 +95,7 @@ IpfsSearchBar.propTypes = searchPropTypes;
 
 
 export default function IpfsSearchBar(props) {
-  const { show, setShow, searchQuery, setSearchQuery, cid = '', setCid, localCids, setLocalCids, showObj, setShowObj } = useSearchDetailsV2();
+  const { show, setShow, searchQuery, setSearchQuery, cid = '', setCid, localCids, setLocalCids, showObj, setShowObj, selectedFrameIndex, setSelectedFrameIndex } = useSearchDetailsV2();
   const params = useParams();
   const [shows, setShows] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -168,6 +168,10 @@ export default function IpfsSearchBar(props) {
       }
     }
   }
+
+  useEffect(() => {
+    setSelectedFrameIndex()
+  }, [params?.subtitleIndex]);
 
 
   /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This PR uses the new data structure to populate the frame, frame fine tuning, and season/episode/subtitle details on a new V2 frame and V2 editor page.

Still to do: Add nearby subtitle and subtitle navigation (with preview frames as before)

Currently the back and forth arrows look at the current subtitle index and either adds or subtracts 1. I have some minimum logic in to stop it from going to 0, but there will also need to be some logic in place to not exceed the total number of subtitle indexes as well.