### PR TITLE
Fix nav arrows and off-by-one miscalculation

### DIFF
--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -1532,7 +1532,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
 
       // eslint-disable-next-line camelcase
       for (let frameId = parseInt(start_frame, 10); frameId <= parseInt(end_frame, 10); frameId += 1) {
-        const fileNumber = Math.floor(frameId / framesPerContainer) + 1;
+        const fileNumber = Math.floor(frameId / framesPerContainer);
         const frameNumber = frameId % framesPerContainer;
         const fileName = `${fileNumber}.mp4`;
         fileFrameGroups[fileName] = fileFrameGroups[fileName] || [];

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -618,7 +618,7 @@ export default function FramePage({ shows = [] }) {
 
       // eslint-disable-next-line camelcase
       for (let frameId = parseInt(start_frame, 10); frameId <= parseInt(end_frame, 10); frameId += 1) {
-        const fileNumber = Math.floor(frameId / framesPerContainer) + 1;
+        const fileNumber = Math.floor(frameId / framesPerContainer);
         const frameNumber = frameId % framesPerContainer;
         const fileName = `${fileNumber}.mp4`;
         fileFrameGroups[fileName] = fileFrameGroups[fileName] || [];

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -673,7 +673,7 @@ export default function FramePage({ shows = [] }) {
               margin: '-10px'
             }}
             onClick={() => {
-              navigate(`/v2/frame/${params?.cid}/${Number(params?.subtitleIndex) + 1}`)
+              navigate(`/v2/frame/${params?.cid}/${Number(params?.subtitleIndex) - 1}`)
             }}
           >
             <ArrowBackIos style={{ fontSize: '2rem' }} />
@@ -691,7 +691,7 @@ export default function FramePage({ shows = [] }) {
               margin: '-10px'
             }}
             onClick={() => {
-              navigate(`/v2/frame/${params?.cid}/${Number(params?.subtitleIndex) - 1}`)
+              navigate(`/v2/frame/${params?.cid}/${Number(params?.subtitleIndex) + 1}`)
             }}
           >
             <ArrowForwardIos style={{ fontSize: '2rem' }} />


### PR DESCRIPTION
Small PR to fix the 'direction' of the nav arrows on the frame page, and correct an off-by-one issue in our `fileNumber` calculations.