### PR TITLE
Admin alias management

### DIFF
--- a/src/components/alias-table-row/AliasTableRow.js
+++ b/src/components/alias-table-row/AliasTableRow.js
@@ -1,0 +1,114 @@
+import { Add } from "@mui/icons-material";
+import { Button, Container, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, TableCell, TableRow, TextField } from "@mui/material";
+import { API, graphqlOperation } from "aws-amplify";
+import { useContext, useState } from "react";
+import { LoadingButton } from "@mui/lab";
+import { getAlias } from "../../graphql/queries";
+import { createAlias, updateAlias } from "../../graphql/mutations";
+import { SnackbarContext } from "../../SnackbarContext";
+/* -------------------------------- Functions ------------------------------- */
+
+const saveCidToAlias = async (cid, alias) => {
+    try {
+        const doesAliasExist = await API.graphql(graphqlOperation(getAlias, { id: alias }))
+
+        if (doesAliasExist?.data?.getAlias?.id) {
+            // The alias exists.
+            const updatedAlias = await API.graphql(graphqlOperation(updateAlias, { input: { id: alias, aliasV2ContentMetadataId: cid } }))
+            console.log(updatedAlias)
+            return {
+                message: 'Alias has been updated!'
+            }
+        }
+        // The alias does not exists.
+        const createdAlias = await API.graphql(graphqlOperation(createAlias, { input: { id: alias, aliasV2ContentMetadataId: cid } }))
+        console.log(createdAlias)
+        return {
+            message: 'Alias has been created!'
+        }
+    } catch (error) {
+        console.log(error)
+        return {
+            message: 'Something went wrong.',
+            error: true
+        }
+    }
+}
+
+export default function AliasTableRow({ row }) {
+    const [saving, setSaving] = useState(false);
+    const [alias, setAlias] = useState('');
+    const [open, setOpen] = useState(false);
+    const { setOpen: setSnackbarOpen, setMessage, setSeverity } = useContext(SnackbarContext)
+
+    const handleClose = () => {
+        setAlias('')
+        setOpen(false)
+    }
+
+    const handleSave = async () => {
+        setSaving(true)
+        const handledAlias = await saveCidToAlias(row.id, alias)
+        if (handledAlias?.error) {
+            setSaving(false)
+            handleClose()
+            setMessage(handledAlias?.message)
+            setSeverity('error')
+            setSnackbarOpen(true)
+        } else {
+            setSaving(false)
+            handleClose()
+            setMessage(handledAlias?.message)
+            setSeverity('success')
+            setSnackbarOpen(true)
+        }
+
+        return null
+    }
+
+
+    return (
+        <>
+            <TableRow
+                key={row.id}
+                sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+            >
+                <TableCell align='left'>
+                    {row?.title}
+                </TableCell>
+                <TableCell align='right'>
+                    <IconButton onClick={() => { setOpen(true) }}>
+                        <Add />
+                    </IconButton>
+                </TableCell>
+            </TableRow>
+            <Dialog
+                open={open}
+                onClose={saving ? () => { } : handleClose}
+                aria-labelledby="alert-dialog-title"
+                aria-describedby="alert-dialog-description"
+            >
+                <DialogTitle id="alert-dialog-title">
+                    Assign to Alias
+                </DialogTitle>
+                <DialogContent>
+                    <TextField
+                        value={alias}
+                        onChange={(event) => {
+                            setAlias(event.target.value)
+                        }}
+                        label='Alias'
+                        fullWidth
+                        sx={{ mt: 2 }}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button variant="contained" disabled={saving} onClick={handleClose}>Cancel</Button>
+                    <LoadingButton color='primary' disabled={saving || !alias} loading={saving} variant="contained" onClick={handleSave}>
+                        Save
+                    </LoadingButton>
+                </DialogActions>
+            </Dialog>
+        </>
+    )
+}

--- a/src/components/alias-table-row/AliasTableRow.js
+++ b/src/components/alias-table-row/AliasTableRow.js
@@ -1,5 +1,5 @@
 import { Add } from "@mui/icons-material";
-import { Button, Container, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, TableCell, TableRow, TextField } from "@mui/material";
+import { Button, Container, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, TableCell, TableRow, TextField, Typography } from "@mui/material";
 import { API, graphqlOperation } from "aws-amplify";
 import { useContext, useState } from "react";
 import { LoadingButton } from "@mui/lab";
@@ -74,7 +74,8 @@ export default function AliasTableRow({ row }) {
                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
             >
                 <TableCell align='left'>
-                    {row?.title}
+                    <Typography fontSize={18}>{row?.title}</Typography>
+                    <Typography fontSize={12}>{row?.id}</Typography>
                 </TableCell>
                 <TableCell align='right'>
                     <IconButton onClick={() => { setOpen(true) }}>

--- a/src/layouts/dashboard/nav/config.js
+++ b/src/layouts/dashboard/nav/config.js
@@ -96,6 +96,12 @@ const navConfig = [
         icon: icon('ic_booking')
       },
       {
+        title: 'Alias Management',
+        path: '/dashboard/aliasmanagement',
+        externalLink: false,
+        icon: icon('ic_booking')
+      },
+      {
         title: 'metadata',
         path: '/dashboard/metadata',
         externalLink: false,

--- a/src/pages/DashboardAliasPage.js
+++ b/src/pages/DashboardAliasPage.js
@@ -1,0 +1,95 @@
+import { Container, Divider, IconButton, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from "@mui/material";
+import { API, graphqlOperation } from "aws-amplify";
+import { useEffect, useState } from "react";
+import { Add } from "@mui/icons-material";
+import { listV2ContentMetadata } from "../graphql/queries";
+import AliasTableRow from "../components/alias-table-row/AliasTableRow";
+
+/* -------------------------------- Functions ------------------------------- */
+
+const getAllMetadataObjects = (nextToken = null) => {
+  return new Promise((resolve, reject) => {
+    API.graphql(
+      graphqlOperation(listV2ContentMetadata, { nextToken })
+    ).then(response => {
+      const newNextToken = response?.data?.listV2ContentMetadata?.nextToken;
+      const items = response?.data?.listV2ContentMetadata?.items;
+      resolve({
+        newNextToken,
+        items
+      });
+    }).catch(error => {
+      reject(error);
+    });
+  });
+};
+
+
+const listMetadataRecursive = async (nextToken = null, allItems = []) => {
+  try {
+    const { newNextToken, items } = await getAllMetadataObjects(nextToken);
+    const updatedItems = allItems.concat(items); // Add the items from the current fetch to the allItems array
+    if (newNextToken) {
+      // If there's a nextToken, recursively call this function with the newNextToken
+      return listMetadataRecursive(newNextToken, updatedItems);
+    }
+    // If there's no nextToken, return all the items fetched
+    return updatedItems;
+  } catch (error) {
+    console.error('Failed to fetch metadata:', error);
+    throw error; // Rethrow the error to be caught by the caller
+  }
+};
+
+/* -------------------------------------------------------------------------- */
+
+const headers = [
+  { id: 'name', label: 'Name', align: 'left' },
+  // Add more header configurations here
+];
+
+const data = [
+  { id: 1, name: 'John Doe', age: 30 },
+  { id: 2, name: 'Jane Doe', age: 25 },
+  // Add more data objects here
+];
+
+
+export default function DashboardAliasPage() {
+  const [loading, setLoading] = useState(true);
+  const [metadatas, setMetadatas] = useState([]);
+
+  useEffect(async () => {
+    listMetadataRecursive()
+      .then(allItems => {
+        setMetadatas(allItems)
+        console.log('All items:', allItems);
+      })
+      .catch(error => {
+        console.error('Error fetching metadata:', error);
+      });
+  }, []);
+
+  return (
+    <>
+      <Container maxWidth='md'>
+        <TableContainer component={Paper}>
+          <Table sx={{ minWidth: 650 }} aria-label="simple table">
+            <TableHead>
+              <TableRow>
+                {headers.map((header) => (
+                  <TableCell key={header.id} sx={{ fontSize: 16}}><b>{header.label}</b></TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {metadatas?.map((row) => (
+                <AliasTableRow row={row} />
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Container>
+    </>
+  )
+}

--- a/src/pages/DashboardAliasPage.js
+++ b/src/pages/DashboardAliasPage.js
@@ -73,6 +73,10 @@ export default function DashboardAliasPage() {
   return (
     <>
       <Container maxWidth='md'>
+        <Typography fontSize={30} fontWeight={700}>
+          Alias Management
+        </Typography>
+        <Divider sx={{ my: 3 }} />
         <TableContainer component={Paper}>
           <Table sx={{ minWidth: 650 }} aria-label="simple table">
             <TableHead>

--- a/src/routes.js
+++ b/src/routes.js
@@ -13,6 +13,7 @@ const InpaintingPage = lazy(() => import('./pages/InpaintingPage'));
 const FramePage = lazy(() => import('./pages/FramePage'));
 const TopBannerSearchRevised = lazy(() => import('./sections/search/TopBannerSeachRevised'));
 const DashboardSeriesPage = lazy(() => import('./pages/DashboardSeriesPage'));
+const DashboardAliasPage = lazy(() => import('./pages/DashboardAliasPage'));
 const DashboardLayout = lazy(() => import('./layouts/dashboard'));
 const BlogPage = lazy(() => import('./pages/BlogPage'));
 const LoginForm = lazy(() => import('./sections/auth/login/LoginForm'));
@@ -105,6 +106,7 @@ export default function Router() {
         { path: 'metadata', element: <MetadataPage /> },
         { path: 'homepagesections', element: <HomepageSectionPage /> },
         { path: 'series', element: <DashboardSeriesPage /> },
+        { path: 'aliasmanagement', element: <DashboardAliasPage /> },
         { path: 'sourcemedia', element: <SourceMediaList /> },
         { path: 'sourcemedia/files/:sourceMediaId', element: <SourceMediaFileList /> },
         { path: 'addseries', element: <AddSeriesPage /> },

--- a/src/sections/@dashboard/alias/alias-management.js
+++ b/src/sections/@dashboard/alias/alias-management.js
@@ -1,0 +1,12 @@
+import { Container, Divider, Typography } from "@mui/material";
+
+export default function AliasManagement({ metadatas = [], reload = () => { } }) {
+    return (
+        <Container maxWidth='lg'>
+            <Typography fontSize={24} fontWeight={700}>
+                Alias Management
+            </Typography>
+            <Divider sx={{ my: 3 }} />
+        </Container>
+    )
+}

--- a/src/utils/fetchShows.js
+++ b/src/utils/fetchShows.js
@@ -35,34 +35,46 @@ const listAliases = /* GraphQL */ `
 `;
 
 export default async function fetchShows() {
-    const result = await API.graphql({
-      ...graphqlOperation(contentMetadataByStatus, { filter: {}, limit: 50, status: 1 }),
-      authMode: 'API_KEY',
-    });
-    const aliases = await API.graphql({
-      ...graphqlOperation(listAliases, { filter: {}, limit: 50 }),
-      authMode: 'API_KEY',
-    });
-  
-    const loadedV1Shows = result?.data?.contentMetadataByStatus?.items || []
-    const loadedV2Shows = aliases?.data?.listAliases?.items || []
-  
-    const combinedShows = loadedV1Shows?.map(v1Show => {
-      const foundReplacement = loadedV2Shows.find(obj => obj.id === v1Show.id)
-  
-      if (foundReplacement) {
-        return { ...foundReplacement?.v2ContentMetadata, id: foundReplacement.id, cid: foundReplacement?.v2ContentMetadata?.id }
-      }
-      
-      return v1Show
-    });
-  
-    console.log(combinedShows)
-  
-    const sortedMetadata = combinedShows.sort((a, b) => {
-      if (a.title < b.title) return -1;
-      if (a.title > b.title) return 1;
-      return 0;
-    });
-    return sortedMetadata;
-  }
+  const result = await API.graphql({
+    ...graphqlOperation(contentMetadataByStatus, { filter: {}, limit: 50, status: 1 }),
+    authMode: 'API_KEY',
+  });
+  const aliases = await API.graphql({
+    ...graphqlOperation(listAliases, { filter: {}, limit: 50 }),
+    authMode: 'API_KEY',
+  });
+
+  const loadedV1Shows = result?.data?.contentMetadataByStatus?.items || [];
+  let loadedV2Shows = aliases?.data?.listAliases?.items || [];
+
+  const usedV2ShowIds = [];
+
+  const combinedShows = loadedV1Shows.map(v1Show => {
+    const foundIndex = loadedV2Shows.findIndex(obj => obj.id === v1Show.id);
+    if (foundIndex > -1) {
+      const foundReplacement = loadedV2Shows[foundIndex];
+      usedV2ShowIds.push(foundReplacement.id);
+      return { ...foundReplacement.v2ContentMetadata, id: foundReplacement.id, cid: foundReplacement.v2ContentMetadata.id };
+    }
+    return v1Show;
+  });
+
+  // Remove used V2 shows from the loadedV2Shows array
+  loadedV2Shows = loadedV2Shows.filter(obj => !usedV2ShowIds.includes(obj.id));
+
+  // Combine the remaining V2 shows with the combinedShows
+  const finalShows = [...combinedShows, ...loadedV2Shows.map(v2Show => ({
+    ...v2Show.v2ContentMetadata,
+    id: v2Show.id,
+    cid: v2Show.v2ContentMetadata.id
+  }))];
+
+  // Sort the final list of shows by title
+  const sortedMetadata = finalShows.sort((a, b) => {
+    if (a.title < b.title) return -1;
+    if (a.title > b.title) return 1;
+    return 0;
+  });
+
+  return sortedMetadata;
+}


### PR DESCRIPTION
This PR adds a very basic list to the admin panel that shows the name of shows with their CID's. Next to this is an add button which shows a dialog in which you can type in an alias to assign to the v2 metadata object. If the alias already exists, it will replace it. If it does not exist, it will create it.

This PR also adds some bug fixes to the fetchShows function.