### PR TITLE
Frame extraction bug

### DIFF
--- a/src/utils/videoFrameExtractor.js
+++ b/src/utils/videoFrameExtractor.js
@@ -39,7 +39,7 @@ export async function extractFramesFromVideo(videoUrl, frameNumbers, assumedFps 
     const blobs = [];
     let currentFrameIndex = 0;
 
-    video.addEventListener('loadedmetadata', () => {
+    video.addEventListener('canplaythrough', () => {
       canvas.width = video.videoWidth*scaleFactor;    // Reduce the resolution a bit for testing performance
       canvas.height = video.videoHeight*scaleFactor;  // Reduce the resolution a bit for testing performance
       
@@ -50,6 +50,7 @@ export async function extractFramesFromVideo(videoUrl, frameNumbers, assumedFps 
       };
 
       video.addEventListener('seeked', async () => {
+        console.log('CURRENT TIME: ', video.currentTime)
         if (currentFrameIndex < frameNumbers.length) {
           context.drawImage(video, 0, 0, canvas.width, canvas.height);
           canvas.toBlob((blob) => {

--- a/src/utils/videoFrameExtractor.js
+++ b/src/utils/videoFrameExtractor.js
@@ -17,6 +17,7 @@ export async function extractVideoFrames(cid, season, episode, frameIndexes, fps
   // Extract frames for each video file
   const fileList = Object.keys(fileFrameGroups).map(async (key) => {
       const videoUrl = `https://ipfs.memesrc.com/ipfs/${cid}/${season}/${episode}/${key}`;
+      console.log(videoUrl)
       const frameBlobs = await extractFramesFromVideo(videoUrl, fileFrameGroups[key], fps, scaleFactor);
       return frameBlobs;
   });
@@ -47,6 +48,7 @@ export async function extractFramesFromVideo(videoUrl, frameNumbers, assumedFps 
         const frameTime = frameIndex / assumedFps;
         console.log("frameTime", frameTime)
         video.currentTime = frameTime;
+        video.pause();
       };
 
       video.addEventListener('seeked', async () => {


### PR DESCRIPTION
This PR fixes frontend issues with frame extraction by swapping the loadedmetadata event listener with the canplaythrough event listener. It also pauses the video after seeking. 