### PR TITLE
Frame page bug fixes and metadata creation

### DIFF
--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -363,6 +363,7 @@ export default function FramePage({ shows = [] }) {
       setFrames([]);
       setSurroundingSubtitles([]);
       setSurroundingFrames(new Array(9).fill('loading'));
+      setEnableFineTuningFrames(false)
 
       // Call the loading functions
       loadInitialFrameInfo().then(() => {

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -364,6 +364,7 @@ export default function FramePage({ shows = [] }) {
       setSurroundingSubtitles([]);
       setSurroundingFrames(new Array(9).fill('loading'));
       setEnableFineTuningFrames(false)
+      setImgSrc()
 
       // Call the loading functions
       loadInitialFrameInfo().then(() => {


### PR DESCRIPTION
This PR fixes the frame page so that the skeleton shows and the load fine tuning frame button reappears when navigating between frames. This also updates the alias management page to create new V2ContentMetadata objects if they don't exist when adding a cid to an alias.