### PR TITLE
Add multi-index support to v2 search endpoint

### DIFF
--- a/amplify/backend/function/memesrcSearchV2/src/event.json
+++ b/amplify/backend/function/memesrcSearchV2/src/event.json
@@ -1,7 +1,7 @@
 {
   "pathParameters": {
-    "id": "seinfeld",
-    "query": "soup%20mode"
+    "id": "seinfeld,seinfeld43,curbyourenthusiasm",
+    "query": "somebody%20get%20a%20sponge"
   },
   "httpMethod": "GET",
   "headers": {

--- a/amplify/backend/function/memesrcSearchV2/src/event.json
+++ b/amplify/backend/function/memesrcSearchV2/src/event.json
@@ -1,6 +1,6 @@
 {
   "pathParameters": {
-    "id": "seinfeld,seinfeld43,curbyourenthusiasm",
+    "id": "seinfeld,seinfeld43,curbyourenthusiasm,testinvalidindex",
     "query": "somebody%20get%20a%20sponge"
   },
   "httpMethod": "GET",

--- a/amplify/backend/function/memesrcSearchV2/src/index.js
+++ b/amplify/backend/function/memesrcSearchV2/src/index.js
@@ -8,58 +8,68 @@ exports.handler = async (event) => {
     
     const { id, query } = event.pathParameters;
     const decodedQuery = decodeURIComponent(query);
+    const indices = id.split(',');
     
     try {
-        const csvUrl = `https://memesrc.com/v2/${id}/_docs.csv`;
-        
-        const csvData = await new Promise((resolve, reject) => {
-            https.get(csvUrl, (response) => {
-                let data = '';
-                response.on('data', (chunk) => {
-                    data += chunk;
+        const promises = indices.map((index) => {
+            const csvUrl = `https://memesrc.com/v2/${index}/_docs.csv`;
+            return new Promise((resolve, reject) => {
+                https.get(csvUrl, (response) => {
+                    let data = '';
+                    response.on('data', (chunk) => {
+                        data += chunk;
+                    });
+                    response.on('end', () => {
+                        resolve({ index, data });
+                    });
+                }).on('error', (error) => {
+                    reject(error);
                 });
-                response.on('end', () => {
-                    resolve(data);
-                });
-            }).on('error', (error) => {
-                reject(error);
             });
         });
         
-        const lines = csvData.split("\n");
-        const headers = lines[0].split(",").map((header) => header.trim());
-        const showObj = lines.slice(1).map((line) => {
-            const values = line.split(",").map((value) => value.trim());
-            return headers.reduce((obj, header, index) => {
-                obj[header] = values[index] ? values[index] : "";
-                if (header === "subtitle_text" && obj[header]) {
-                    obj.base64_subtitle = obj[header];
-                    obj[header] = atob(obj[header]);
+        const csvDataArray = await Promise.all(promises);
+        
+        let combinedResults = [];
+        
+        for (const { index, data } of csvDataArray) {
+            const lines = data.split("\n");
+            const headers = lines[0].split(",").map((header) => header.trim());
+            const showObj = lines.slice(1).map((line) => {
+                const values = line.split(",").map((value) => value.trim());
+                return headers.reduce((obj, header, index) => {
+                    obj[header] = values[index] ? values[index] : "";
+                    if (header === "subtitle_text" && obj[header]) {
+                        obj.base64_subtitle = obj[header];
+                        obj[header] = atob(obj[header]);
+                    }
+                    return obj;
+                }, {});
+            });
+            
+            const searchTerms = decodedQuery.trim().toLowerCase().split(" ");
+            let results = [];
+            showObj.forEach((line) => {
+                let score = 0;
+                if (line.subtitle_text.toLowerCase().includes(decodedQuery)) {
+                    score += 10;
                 }
-                return obj;
-            }, {});
-        });
-
-        const searchTerms = decodedQuery.trim().toLowerCase().split(" ");
-        let results = [];
-        showObj.forEach((line) => {
-            let score = 0;
-            if (line.subtitle_text.toLowerCase().includes(decodedQuery)) {
-                score += 10;
-            }
-            searchTerms.forEach((term) => {
-                if (line.subtitle_text.toLowerCase().includes(term)) {
-                    score += 1;
+                searchTerms.forEach((term) => {
+                    if (line.subtitle_text.toLowerCase().includes(term)) {
+                        score += 1;
+                    }
+                });
+                if (score > 0) {
+                    results.push({ ...line, score, index_id: index });
                 }
             });
-            if (score > 0) {
-                results.push({ ...line, score });
-            }
-        });
-
-        results.sort((a, b) => b.score - a.score);
-        results = results.slice(0, 150);
-
+            
+            combinedResults = combinedResults.concat(results);
+        }
+        
+        combinedResults.sort((a, b) => b.score - a.score);
+        combinedResults = combinedResults.slice(0, 150);
+        
         return {
             statusCode: 200,
             headers: {
@@ -67,7 +77,7 @@ exports.handler = async (event) => {
                 "Access-Control-Allow-Headers": "*",
                 "Content-Type": "application/json"
             },
-            body: JSON.stringify(results),
+            body: JSON.stringify(combinedResults),
         };
     } catch (error) {
         console.error("Error:", error);

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -119,7 +119,7 @@
         },
         "memesrcSearchV2": {
           "deploymentBucketName": "amplify-memesrc-dev-191629-deployment",
-          "s3Key": "amplify-builds/memesrcSearchV2-636b494b64584d384169-build.zip"
+          "s3Key": "amplify-builds/memesrcSearchV2-54616f4e712f76307872-build.zip"
         },
         "memesrcThumbnailZipExtractor": {
           "deploymentBucketName": "amplify-memesrc-dev-191629-deployment",

--- a/src/pages/V2SearchPage.js
+++ b/src/pages/V2SearchPage.js
@@ -335,8 +335,8 @@ export default function SearchPage() {
           throw new Error(`HTTP error! Status: ${response.status}`);
         }
         const results = await response.json();
-        setNewResults(results);
-        setLoadingResults(false);
+        setNewResults(results.results);
+        // setOfflineIndexes(results.offline_indexes);
         results.forEach((result) => loadVideoUrl(result, cid));
       } catch (error) {
         console.error("Error searching:", error);
@@ -536,6 +536,11 @@ export default function SearchPage() {
                     )}
                     <BottomCardCaption>{result.subtitle_text}</BottomCardCaption>
                     <BottomCardLabel>
+                      <Chip
+                        size="small"
+                        label={result.index_id}
+                        style={{ backgroundColor: 'rgba(0, 0, 0, 0.3)', color: 'white', fontWeight: 'bold' }}
+                      />
                       <Chip
                         size="small"
                         label={`S${result.season} E${result.episode}`}


### PR DESCRIPTION
# Description

This PR updates the v2 search endpoint to support multiple indexes (comma separated).

# Example

`/v2/search/exampleone,exampletwo,exampleinvalid/test%20search`

Returns: 

```json
{
    "results": [
        {
            "season": "...",
            "episode": "...",
            "subtitle_index": "...",
            "subtitle_text": "...",
            "base64_subtitle": "...",
            "start_frame": "...",
            "end_frame": "...",
            "score": 1,
            "index_id": "exampleone"
        },
        {
            "season": "...",
            "episode": "...",
            "subtitle_index": "...",
            "subtitle_text": "...",
            "base64_subtitle": "...",
            "start_frame": "...",
            "end_frame": "...",
            "score": 1,
            "index_id": "exampletwo"
        },
        { 
            "..." 
        },
    ],
    "offline_indexes": [ "exampleinvalid" ]
}
```

The `offline_indexes` key contains an array of indexes which were 'offline' (their docs couldn't be found).