### PR TITLE
Isolate v2 endpoint environments

### DIFF
--- a/amplify/backend/api/publicapi/override.ts
+++ b/amplify/backend/api/publicapi/override.ts
@@ -2,5 +2,5 @@
 import { AmplifyApiRestResourceStackTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyApiRestResourceStackTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
-    resources.restApi.binaryMediaTypes = ["image~1jpeg", "image~1png", "image~1gif"];
+    resources.restApi.binaryMediaTypes = ["*~1*"];
 }

--- a/amplify/backend/api/publicapi/override.ts
+++ b/amplify/backend/api/publicapi/override.ts
@@ -1,0 +1,6 @@
+// This file is used to override the REST API resources configuration
+import { AmplifyApiRestResourceStackTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
+
+export function override(resources: AmplifyApiRestResourceStackTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
+    resources.restApi.binaryMediaTypes = ["image~1jpeg", "image~1png", "image~1gif"];
+}

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -119,7 +119,7 @@
         },
         "memesrcSearchV2": {
           "deploymentBucketName": "amplify-memesrc-dev-191629-deployment",
-          "s3Key": "amplify-builds/memesrcSearchV2-54616f4e712f76307872-build.zip"
+          "s3Key": "amplify-builds/memesrcSearchV2-6561525336517279774d-build.zip"
         },
         "memesrcThumbnailZipExtractor": {
           "deploymentBucketName": "amplify-memesrc-dev-191629-deployment",

--- a/src/pages/V2SearchPage.js
+++ b/src/pages/V2SearchPage.js
@@ -284,8 +284,8 @@ export default function SearchPage() {
 
   const loadVideoUrl = async (result, metadataCid) => {
     const thumbnailUrl = animationsEnabled
-      ? `https://v2.memesrc.com/thumbnail/${metadataCid}/${result.season}/${result.episode}/${result.subtitle_index}`
-      : `https://v2.memesrc.com/frame/${metadataCid}/${result.season}/${result.episode}/${Math.round((parseInt(result.start_frame, 10) + parseInt(result.end_frame, 10)) / 2)}`;
+      ? `https://v2-dev.memesrc.com/thumbnail/${metadataCid}/${result.season}/${result.episode}/${result.subtitle_index}`
+      : `https://v2-dev.memesrc.com/frame/${metadataCid}/${result.season}/${result.episode}/${Math.round((parseInt(result.start_frame, 10) + parseInt(result.end_frame, 10)) / 2)}`;
     const resultId = `${result.season}-${result.episode}-${result.subtitle_index}`;
     setVideoUrls((prevVideoUrls) => ({ ...prevVideoUrls, [resultId]: thumbnailUrl }));
   };
@@ -330,7 +330,7 @@ export default function SearchPage() {
       }
   
       try {
-        const response = await fetch(`https://v2.memesrc.com/search/${cid}/${searchTerm}`);
+        const response = await fetch(`https://v2-dev.memesrc.com/search/${cid}/${searchTerm}`);
         if (!response.ok) {
           throw new Error(`HTTP error! Status: ${response.status}`);
         }

--- a/src/pages/V2SearchPage.js
+++ b/src/pages/V2SearchPage.js
@@ -284,8 +284,8 @@ export default function SearchPage() {
 
   const loadVideoUrl = async (result, metadataCid) => {
     const thumbnailUrl = animationsEnabled
-      ? `https://v2-dev.memesrc.com/thumbnail/${metadataCid}/${result.season}/${result.episode}/${result.subtitle_index}`
-      : `https://v2-dev.memesrc.com/frame/${metadataCid}/${result.season}/${result.episode}/${Math.round((parseInt(result.start_frame, 10) + parseInt(result.end_frame, 10)) / 2)}`;
+      ? `https://v2-${process.env.REACT_APP_USER_BRANCH}.memesrc.com/thumbnail/${metadataCid}/${result.season}/${result.episode}/${result.subtitle_index}`
+      : `https://v2-${process.env.REACT_APP_USER_BRANCH}.memesrc.com/frame/${metadataCid}/${result.season}/${result.episode}/${Math.round((parseInt(result.start_frame, 10) + parseInt(result.end_frame, 10)) / 2)}`;
     const resultId = `${result.season}-${result.episode}-${result.subtitle_index}`;
     setVideoUrls((prevVideoUrls) => ({ ...prevVideoUrls, [resultId]: thumbnailUrl }));
   };
@@ -330,7 +330,7 @@ export default function SearchPage() {
       }
   
       try {
-        const response = await fetch(`https://v2-dev.memesrc.com/search/${cid}/${searchTerm}`);
+        const response = await fetch(`https://v2-${process.env.REACT_APP_USER_BRANCH}.memesrc.com/search/${cid}/${searchTerm}`);
         if (!response.ok) {
           throw new Error(`HTTP error! Status: ${response.status}`);
         }

--- a/src/utils/videoFrameExtractor.js
+++ b/src/utils/videoFrameExtractor.js
@@ -1,6 +1,6 @@
 export async function extractVideoFrames(cid, season, episode, frameIndexes, fps, scaleFactor) {
   const frameUrls = frameIndexes.map(frameId => {
-    return `https://v2.memesrc.com/frame/${cid}/${season}/${episode}/${frameId}`;
+    return `https://v2-dev.memesrc.com/frame/${cid}/${season}/${episode}/${frameId}`;
   });
 
   return frameUrls;

--- a/src/utils/videoFrameExtractor.js
+++ b/src/utils/videoFrameExtractor.js
@@ -1,6 +1,6 @@
 export async function extractVideoFrames(cid, season, episode, frameIndexes, fps, scaleFactor) {
   const frameUrls = frameIndexes.map(frameId => {
-    return `https://v2-dev.memesrc.com/frame/${cid}/${season}/${episode}/${frameId}`;
+    return `https://v2-${process.env.REACT_APP_USER_BRANCH}.memesrc.com/frame/${cid}/${season}/${episode}/${frameId}`;
   });
 
   return frameUrls;


### PR DESCRIPTION
This PR isolates the usage of v2 endpoints to their respective environments. Previously, they were all using `dev` endpoint behind a CDN to lean on exploratory changes made in AWS Console. To formalize those settings, these changes were made:

1. Add `override.ts` to handle binary content type setting for each env
1. Add CloudFront distros for each env (`v2-beta` and `v2-dev`)
1. Add Route53 records for the env-specific distros
1. Switch to env-specific cdn urls on the app

**Note:** the CloudFront and Route53 changes are not in the codebase since those are still manually adjusted in the AWS Console directly