### PR TITLE
Hotfix for API issues

### DIFF
--- a/amplify/backend/api/publicapi/override.ts
+++ b/amplify/backend/api/publicapi/override.ts
@@ -2,5 +2,5 @@
 import { AmplifyApiRestResourceStackTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyApiRestResourceStackTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
-    // resources.restApi.binaryMediaTypes = ["*~1*"];
+    resources.restApi.binaryMediaTypes = ["image/jpeg"];
 }

--- a/amplify/backend/api/publicapi/override.ts
+++ b/amplify/backend/api/publicapi/override.ts
@@ -2,5 +2,5 @@
 import { AmplifyApiRestResourceStackTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyApiRestResourceStackTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
-    resources.restApi.binaryMediaTypes = ["*~1*"];
+    // resources.restApi.binaryMediaTypes = ["*~1*"];
 }


### PR DESCRIPTION
# Description

This PR temporarily removes the binary content type handling to 'hotfix' the app failures due to CORS issues. In other words, this temporarily sacrifices V2 handlers to recover all over API actions in the app. 

**Note:** Since V2 handling is currently down, I've temporarily removed all alias definitions on the beta app to use V1 searches.

## Background

The `*/*` binary content type setting in https://github.com/Vibe-House-LLC/memeSRC/pull/196 changes the behavior of the REST API's options requests, which breaks most functionality in the app (due to preflight CORS issues). 

## Pending Solution

I was using `*/*` because I can't get explicit binary content types to work (i.e. `image/jpeg`, `image/gif`, and `video/mp4`) working due to the "Accept" header handling of this setting on AWS (see "Important" section of [this doc](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings.html)). 

We could probably solve this in one of a few different way. Either: 

- Use `*/*` wildcard, but add necessary CORS headers to lambda responses
- Use explicit types, but try to solve the issues (which I think relate to Accept headers, see [this doc](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings.html))
- (???) any ideas (???)