### PR TITLE
Add and utilize standalone v2 content api 

### DIFF
--- a/amplify/backend/api/APIGatewayAuthStack.json
+++ b/amplify/backend/api/APIGatewayAuthStack.json
@@ -13,6 +13,9 @@
     },
     "publicapi": {
       "Type": "String"
+    },
+    "memesrcContentApi": {
+      "Type": "String"
     }
   },
   "Conditions": {

--- a/amplify/backend/api/memesrcContentApi/cli-inputs.json
+++ b/amplify/backend/api/memesrcContentApi/cli-inputs.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "paths": {
+    "/frame/{index}/{season}/{episode}/{frame}": {
+      "name": "/frame/{index}/{season}/{episode}/{frame}",
+      "lambdaFunction": "frameExtractor",
+      "permissions": {
+        "setting": "open"
+      }
+    },
+    "/gif/{id}/{season}/{episode}/{range}": {
+      "name": "/gif/{id}/{season}/{episode}/{range}",
+      "lambdaFunction": "memesrcGif",
+      "permissions": {
+        "setting": "open"
+      }
+    },
+    "/search/{id}/{query}": {
+      "name": "/search/{id}/{query}",
+      "lambdaFunction": "memesrcSearchV2",
+      "permissions": {
+        "setting": "open"
+      }
+    },
+    "/thumbnail/{id}/{season}/{episode}/{subtitle}": {
+      "name": "/thumbnail/{id}/{season}/{episode}/{subtitle}",
+      "lambdaFunction": "memesrcThumbnailZipExtractor",
+      "permissions": {
+        "setting": "open"
+      }
+    }
+  }
+}

--- a/amplify/backend/api/memesrcContentApi/override.ts
+++ b/amplify/backend/api/memesrcContentApi/override.ts
@@ -1,0 +1,6 @@
+// This file is used to override the REST API resources configuration
+import { AmplifyApiRestResourceStackTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
+
+export function override(resources: AmplifyApiRestResourceStackTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
+    resources.restApi.binaryMediaTypes = ["*/*"];
+}

--- a/amplify/backend/api/publicapi/override.ts
+++ b/amplify/backend/api/publicapi/override.ts
@@ -1,6 +1,6 @@
-// This file is used to override the REST API resources configuration
-import { AmplifyApiRestResourceStackTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
+// // This file is used to override the REST API resources configuration
+// import { AmplifyApiRestResourceStackTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyApiRestResourceStackTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
-    resources.restApi.binaryMediaTypes = ["image/jpeg"];
-}
+// export function override(resources: AmplifyApiRestResourceStackTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
+//     resources.restApi.binaryMediaTypes = ["*/*"];
+// }

--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -58,6 +58,44 @@
       "providerPlugin": "awscloudformation",
       "service": "AppSync"
     },
+    "memesrcContentApi": {
+      "dependsOn": [
+        {
+          "attributes": [
+            "Name",
+            "Arn"
+          ],
+          "category": "function",
+          "resourceName": "frameExtractor"
+        },
+        {
+          "attributes": [
+            "Name",
+            "Arn"
+          ],
+          "category": "function",
+          "resourceName": "memesrcGif"
+        },
+        {
+          "attributes": [
+            "Name",
+            "Arn"
+          ],
+          "category": "function",
+          "resourceName": "memesrcSearchV2"
+        },
+        {
+          "attributes": [
+            "Name",
+            "Arn"
+          ],
+          "category": "function",
+          "resourceName": "memesrcThumbnailZipExtractor"
+        }
+      ],
+      "providerPlugin": "awscloudformation",
+      "service": "API Gateway"
+    },
     "publicapi": {
       "dependsOn": [
         {

--- a/amplify/backend/types/amplify-dependent-resources-ref.d.ts
+++ b/amplify/backend/types/amplify-dependent-resources-ref.d.ts
@@ -10,6 +10,11 @@ export type AmplifyDependentResourcesAttributes = {
       "GraphQLAPIIdOutput": "string",
       "GraphQLAPIKeyOutput": "string"
     },
+    "memesrcContentApi": {
+      "ApiId": "string",
+      "ApiName": "string",
+      "RootUrl": "string"
+    },
     "publicapi": {
       "ApiId": "string",
       "ApiName": "string",

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -23,7 +23,8 @@
       "api": {
         "memesrc": {},
         "AdminQueries": {},
-        "publicapi": {}
+        "publicapi": {},
+        "memesrcContentApi": {}
       },
       "function": {
         "AdminQueries9e1cafc6": {


### PR DESCRIPTION
# Description

In response to the issues described in https://github.com/Vibe-House-LLC/memeSRC/pull/197, this PR adds and utilizes a standalone REST API specifically for service and searching V2 content. 

In other words, this brings back the V2 content handling which was disabled in hotfix https://github.com/Vibe-House-LLC/memeSRC/pull/197

## AWS Console Changes

Not included in this PR is swapping the origins for each env-specific CloudFront distro to utilize the new content api.