### PR TITLE
Website settings page

### DIFF
--- a/amplify/backend/api/memesrc/schema.graphql
+++ b/amplify/backend/api/memesrc/schema.graphql
@@ -294,5 +294,6 @@ type WebsiteSetting @model @auth(
   ]
 ) {
   id: ID!, 
-  value: Boolean
+  fullSiteMaintenance: Boolean,
+  universalSearchMaintenance: Boolean
 }

--- a/amplify/backend/function/memesrcSearchV2/src/index.js
+++ b/amplify/backend/function/memesrcSearchV2/src/index.js
@@ -7,6 +7,7 @@ const path = require('path');
  */
 exports.handler = async (event) => {
     console.log(`EVENT: ${JSON.stringify(event)}`);
+    console.log('Throw Away Console Log')
     
     const { id, query } = event.pathParameters;
     const decodedQuery = decodeURIComponent(query);

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -1880,7 +1880,8 @@ export const createWebsiteSetting = /* GraphQL */ `
   ) {
     createWebsiteSetting(input: $input, condition: $condition) {
       id
-      value
+      fullSiteMaintenance
+      universalSearchMaintenance
       createdAt
       updatedAt
       __typename
@@ -1894,7 +1895,8 @@ export const updateWebsiteSetting = /* GraphQL */ `
   ) {
     updateWebsiteSetting(input: $input, condition: $condition) {
       id
-      value
+      fullSiteMaintenance
+      universalSearchMaintenance
       createdAt
       updatedAt
       __typename
@@ -1908,7 +1910,8 @@ export const deleteWebsiteSetting = /* GraphQL */ `
   ) {
     deleteWebsiteSetting(input: $input, condition: $condition) {
       id
-      value
+      fullSiteMaintenance
+      universalSearchMaintenance
       createdAt
       updatedAt
       __typename

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -1142,7 +1142,8 @@ export const getWebsiteSetting = /* GraphQL */ `
   query GetWebsiteSetting($id: ID!) {
     getWebsiteSetting(id: $id) {
       id
-      value
+      fullSiteMaintenance
+      universalSearchMaintenance
       createdAt
       updatedAt
       __typename
@@ -1158,7 +1159,8 @@ export const listWebsiteSettings = /* GraphQL */ `
     listWebsiteSettings(filter: $filter, limit: $limit, nextToken: $nextToken) {
       items {
         id
-        value
+        fullSiteMaintenance
+        universalSearchMaintenance
         createdAt
         updatedAt
         __typename

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -8456,7 +8456,18 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "value",
+          "name" : "fullSiteMaintenance",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "universalSearchMaintenance",
           "description" : null,
           "args" : [ ],
           "type" : {
@@ -8555,7 +8566,16 @@
           },
           "defaultValue" : null
         }, {
-          "name" : "value",
+          "name" : "fullSiteMaintenance",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelBooleanInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "universalSearchMaintenance",
           "description" : null,
           "type" : {
             "kind" : "INPUT_OBJECT",
@@ -15516,7 +15536,16 @@
           },
           "defaultValue" : null
         }, {
-          "name" : "value",
+          "name" : "fullSiteMaintenance",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "universalSearchMaintenance",
           "description" : null,
           "type" : {
             "kind" : "SCALAR",
@@ -15534,7 +15563,16 @@
         "description" : null,
         "fields" : null,
         "inputFields" : [ {
-          "name" : "value",
+          "name" : "fullSiteMaintenance",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelBooleanInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "universalSearchMaintenance",
           "description" : null,
           "type" : {
             "kind" : "INPUT_OBJECT",
@@ -15600,7 +15638,16 @@
           },
           "defaultValue" : null
         }, {
-          "name" : "value",
+          "name" : "fullSiteMaintenance",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "universalSearchMaintenance",
           "description" : null,
           "type" : {
             "kind" : "SCALAR",
@@ -19334,7 +19381,16 @@
           },
           "defaultValue" : null
         }, {
-          "name" : "value",
+          "name" : "fullSiteMaintenance",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionBooleanInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "universalSearchMaintenance",
           "description" : null,
           "type" : {
             "kind" : "INPUT_OBJECT",
@@ -20485,51 +20541,6 @@
         "onFragment" : false,
         "onField" : true
       }, {
-        "name" : "aws_iam",
-        "description" : "Tells the service this field/object has access authorized by sigv4 signing.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
-        "args" : [ ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "aws_lambda",
-        "description" : "Tells the service this field/object has access authorized by a Lambda Authorizer.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
-        "args" : [ ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "aws_api_key",
-        "description" : "Tells the service this field/object has access authorized by an API key.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
-        "args" : [ ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "aws_publish",
-        "description" : "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
-        "locations" : [ "FIELD_DEFINITION" ],
-        "args" : [ {
-          "name" : "subscriptions",
-          "description" : "List of subscriptions which will be published to when this mutation is called.",
-          "type" : {
-            "kind" : "LIST",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        } ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
         "name" : "aws_cognito_user_pools",
         "description" : "Tells the service this field/object has access authorized by a Cognito User Pools token.",
         "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
@@ -20551,18 +20562,30 @@
         "onFragment" : false,
         "onField" : false
       }, {
-        "name" : "deprecated",
-        "description" : null,
-        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
+        "name" : "aws_lambda",
+        "description" : "Tells the service this field/object has access authorized by a Lambda Authorizer.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_subscribe",
+        "description" : "Tells the service which mutation triggers this subscription.",
+        "locations" : [ "FIELD_DEFINITION" ],
         "args" : [ {
-          "name" : "reason",
-          "description" : null,
+          "name" : "mutations",
+          "description" : "List of mutations which will trigger this subscription when they are called.",
           "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
-            "ofType" : null
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
           },
-          "defaultValue" : "\"No longer supported\""
+          "defaultValue" : null
         } ],
         "onOperation" : false,
         "onFragment" : false,
@@ -20589,12 +20612,12 @@
         "onFragment" : false,
         "onField" : false
       }, {
-        "name" : "aws_subscribe",
-        "description" : "Tells the service which mutation triggers this subscription.",
+        "name" : "aws_publish",
+        "description" : "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
         "locations" : [ "FIELD_DEFINITION" ],
         "args" : [ {
-          "name" : "mutations",
-          "description" : "List of mutations which will trigger this subscription when they are called.",
+          "name" : "subscriptions",
+          "description" : "List of subscriptions which will be published to when this mutation is called.",
           "type" : {
             "kind" : "LIST",
             "name" : null,
@@ -20610,8 +20633,41 @@
         "onFragment" : false,
         "onField" : false
       }, {
+        "name" : "aws_api_key",
+        "description" : "Tells the service this field/object has access authorized by an API key.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "deprecated",
+        "description" : null,
+        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
+        "args" : [ {
+          "name" : "reason",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : "\"No longer supported\""
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
         "name" : "aws_oidc",
         "description" : "Tells the service this field/object has access authorized by an OIDC token.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_iam",
+        "description" : "Tells the service this field/object has access authorized by sigv4 signing.",
         "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
         "args" : [ ],
         "onOperation" : false,

--- a/src/graphql/subscriptions.js
+++ b/src/graphql/subscriptions.js
@@ -1786,7 +1786,8 @@ export const onCreateWebsiteSetting = /* GraphQL */ `
   ) {
     onCreateWebsiteSetting(filter: $filter) {
       id
-      value
+      fullSiteMaintenance
+      universalSearchMaintenance
       createdAt
       updatedAt
       __typename
@@ -1799,7 +1800,8 @@ export const onUpdateWebsiteSetting = /* GraphQL */ `
   ) {
     onUpdateWebsiteSetting(filter: $filter) {
       id
-      value
+      fullSiteMaintenance
+      universalSearchMaintenance
       createdAt
       updatedAt
       __typename
@@ -1812,7 +1814,8 @@ export const onDeleteWebsiteSetting = /* GraphQL */ `
   ) {
     onDeleteWebsiteSetting(filter: $filter) {
       id
-      value
+      fullSiteMaintenance
+      universalSearchMaintenance
       createdAt
       updatedAt
       __typename

--- a/src/pages/SiteWideMaintenance.js
+++ b/src/pages/SiteWideMaintenance.js
@@ -1,0 +1,103 @@
+import { Helmet } from 'react-helmet-async';
+import { useContext, useEffect, useState } from 'react';
+import { styled } from '@mui/material/styles';
+import { Container, Typography } from '@mui/material';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { API, graphqlOperation } from 'aws-amplify';
+import Logo from '../components/logo';
+import VerifyForm from '../sections/auth/login/VerifyForm';
+import SignupForm from '../sections/auth/login/SignupForm';
+import { UserContext } from '../UserContext';
+import { getWebsiteSetting } from '../graphql/queries';
+
+// ----------------------------------------------------------------------
+
+const StyledRoot = styled('div')(({ theme }) => ({
+  [theme.breakpoints.up('md')]: {
+    display: 'flex',
+  },
+}));
+
+const StyledContent = styled('div')(({ theme }) => ({
+  maxWidth: 880,
+  margin: 'auto',
+  minHeight: '100vh',
+  display: 'flex',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  padding: theme.spacing(12, 0),
+}));
+
+// ----------------------------------------------------------------------
+
+export default function SiteWideMaintenance({ children }) {
+  const [maintenance, setMaintenance] = useState();
+  const [loading, setLoading] = useState(true);
+
+
+  useEffect(() => {
+    setLoading(true)
+    API.graphql(
+      {
+        ...graphqlOperation(getWebsiteSetting, { id: 'globalSettings' }),
+        authMode: 'API_KEY'
+      }
+    ).then(response => {
+      setMaintenance(response?.data?.getWebsiteSetting?.fullSiteMaintenance);
+      console.log(response?.data?.getWebsiteSetting?.fullSiteMaintenance)
+      setLoading(false)
+    }).catch(error => {
+      console.log(error)
+      setLoading(false)
+    })
+  }, []);
+
+  // Return the page
+  return (
+    <>
+      {!loading &&
+        <>
+          {maintenance ?
+            <>
+              <Helmet>
+                <title> Site Wide Maintenance • memeSRC </title>
+              </Helmet>
+
+              <StyledRoot>
+                {/* <Link to='/'>
+                  <Logo
+                    sx={{
+                      position: 'fixed',
+                      top: { xs: 16, sm: 24, md: 40 },
+                      left: { xs: 16, sm: 24, md: 40 },
+                    }}
+                  />
+                </Link> */}
+
+                <Container maxWidth="md">
+                  <StyledContent>
+                    <Typography fontSize={40} fontWeight={800} textAlign='center'>
+                      We are currently down for maintenance.
+                    </Typography>
+                    <Typography fontSize={26} textAlign='center' pt={5}>
+                      Please try again later.
+                    </Typography>
+                  </StyledContent>
+                </Container>
+              </StyledRoot>
+            </>
+            :
+            <>
+              {children}
+            </>
+          }
+        </>
+      }
+    </>
+  );
+};
+
+// AuthPage.propTypes = {
+//   method: PropTypes.string.isRequired,
+// };

--- a/src/pages/WebsiteSettings.js
+++ b/src/pages/WebsiteSettings.js
@@ -1,48 +1,97 @@
-import { Card, Container, Divider, FormControlLabel, FormGroup, Grid, Switch, Typography } from "@mui/material";
-import { useState } from "react";
+import { Card, Container, Divider, FormControlLabel, FormGroup, Grid, LinearProgress, Stack, Switch, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+import { Helmet } from "react-helmet-async";
+import { API, graphqlOperation } from "aws-amplify";
+import { createWebsiteSetting, updateWebsiteSetting } from "../graphql/mutations";
+import { getWebsiteSetting } from "../graphql/queries";
+import MaintenanceModes from "../sections/@dashboard/website-settings/MaintenanceModes";
 
 export default function WebsiteSettings() {
-    const [loading, setLoading] = useState(false);
+    const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [fullSiteMaintenance, setFullSiteMaintenance] = useState(false);
+    const [universalSearchMaintenance, setUniversalSearchMaintenance] = useState(false);
+    const [globalSettings, setGlobalSettings] = useState();
+
+    useEffect(() => {
+
+        API.graphql(
+            graphqlOperation(getWebsiteSetting, { id: 'globalSettings' })
+        ).then(response => {
+            console.log(response)
+            if (response?.data?.getWebsiteSetting) {
+                const globalSettings = response?.data?.getWebsiteSetting
+                setGlobalSettings(globalSettings || {})
+                setFullSiteMaintenance(globalSettings?.fullSiteMaintenance || false)
+                setUniversalSearchMaintenance(globalSettings?.universalSearchMaintenance || false)
+                setLoading(false)
+            } else {
+                setGlobalSettings()
+                setFullSiteMaintenance(false)
+                setUniversalSearchMaintenance(false)
+                setLoading(false)
+            }
+        }).catch(error => {
+            console.log(error)
+            setLoading(false)
+        })
+
+        return () => {
+            setGlobalSettings({})
+        }
+    }, []);
+
+    const saveMaintenance = async () => {
+        setSaving(true)
+        try {
+            if (!globalSettings) {
+                const createGlobalSettings = await API.graphql(
+                    graphqlOperation(createWebsiteSetting, { input: { id: 'globalSettings' }})
+                )
+                console.log(createGlobalSettings)
+            }
+
+            const updateGlobalSettings = await API.graphql(
+                graphqlOperation(updateWebsiteSetting, { input: { id: 'globalSettings', fullSiteMaintenance, universalSearchMaintenance }})
+            )
+            console.log(updateGlobalSettings)
+            setGlobalSettings(updateGlobalSettings?.data?.updateWebsiteSetting)
+            setSaving(false)
+        } catch (error) {
+            console.log(error)
+            setSaving(false)
+        }
+        
+    }
 
     return (
-        <Container maxWidth='lg' sx={{ mt: 5 }}>
-            <Typography fontSize={34} fontWeight={700}>
-                Website Settings
-            </Typography>
-            <Typography fontSize={16} fontWeight={700}>
-                Admin only website website functions
-            </Typography>
-            <Divider sx={{ my: 4 }} />
-            <Grid container spacing={3}>
-                <Grid item xs={12} md={4}>
-                    <Typography fontSize={24} fontWeight={700}>
-                        Kill Switches
-                    </Typography>
-                    <Typography fontSize={14} fontWeight={500}>
-                        Disable features or the entire website
-                    </Typography>
-                </Grid>
-                <Grid item xs={12} md={8}>
-                    <Card sx={{ p: 2 }} variant='outlined'>
-                        <FormGroup>
-                            <FormControlLabel
-                                control={
-                                    <Switch
-                                        disabled={loading || saving}
-                                        checked={fullSiteMaintenance}
-                                        onChange={(event) => {
-                                            setFullSiteMaintenance(event.target.checked)
-                                        }}
-                                    />
-                                }
-                                label="Full Site Maintenance Mode"
-                            />
-                        </FormGroup>
-                    </Card>
-                </Grid>
-            </Grid>
-        </Container>
+        <>
+            <Helmet>
+                <title>Website Settings - memeSRC 2.0</title>
+            </Helmet>
+            <Container maxWidth='lg' sx={{ mt: 5 }}>
+                <Typography fontSize={34} fontWeight={700}>
+                    Website Settings
+                </Typography>
+                <Typography fontSize={16} fontWeight={700}>
+                    Admin only website website functions
+                </Typography>
+                <Divider sx={{ my: 4 }} />
+                {!loading &&
+                    <MaintenanceModes
+                        saveFunction={saveMaintenance}
+                        saving={saving}
+                        fullSiteMaintenance={fullSiteMaintenance}
+                        universalSearchMaintenance={universalSearchMaintenance}
+                        setFullSiteMaintenance={setFullSiteMaintenance}
+                        setUniversalSearchMaintenance={setUniversalSearchMaintenance}
+                        currentSettings={globalSettings}
+                    />
+                }
+                {loading &&
+                    <LinearProgress sx={{ mt: 5 }} />
+                }
+            </Container>
+        </>
     )
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,6 +3,7 @@ import { lazy } from 'react';
 import EditorNewProjectPage from './pages/EditorNewProjectPage';
 import EditorProjectsPage from './pages/EditorProjectsPage';
 import { V2SearchDetailsProvider } from './contexts/V2SearchDetailsProvider';
+import SiteWideMaintenance from './pages/SiteWideMaintenance';
 
 
 // ----------------------------------------------------------------------
@@ -58,24 +59,25 @@ const WebsiteSettings = lazy(() => import('./pages/WebsiteSettings'))
 // ----------------------------------------------------------------------
 
 export default function Router() {
+   
 
   const routes = useRoutes([
     {
       path: '/',
       element: <GuestAuth><MagicPopup><V2SearchDetailsProvider><DashboardLayout /></V2SearchDetailsProvider></MagicPopup></GuestAuth>,
       children: [
-        { element: <HomePage />, index: true },
-        { path: 'search', element: <Navigate to='/' /> },
-        { path: 'edit', element: <EditorNewProjectPage /> },
-        { path: 'editor/projects', element: <EditorProjectsPage /> },
-        { path: 'editor/new', element: <EditorNewProjectPage /> },
-        { path: 'editor/project/:editorProjectId', element: <EditorPage /> },
-        { path: 'search/:seriesId', element: <SearchPage /> },
-        { path: 'search/:seriesId/:searchTerms', element: <SearchPage /> },
-        { path: 'favorites', element: <FavoritesPage /> },
+        { element: <SiteWideMaintenance><HomePage /></SiteWideMaintenance>, index: true },
+        { path: 'search', element: <SiteWideMaintenance><Navigate to='/' /></SiteWideMaintenance> },
+        { path: 'edit', element: <SiteWideMaintenance><EditorNewProjectPage /></SiteWideMaintenance> },
+        { path: 'editor/projects', element: <SiteWideMaintenance><EditorProjectsPage /></SiteWideMaintenance> },
+        { path: 'editor/new', element: <SiteWideMaintenance><EditorNewProjectPage /></SiteWideMaintenance> },
+        { path: 'editor/project/:editorProjectId', element: <SiteWideMaintenance><EditorPage /></SiteWideMaintenance> },
+        { path: 'search/:seriesId', element: <SiteWideMaintenance><SearchPage /></SiteWideMaintenance> },
+        { path: 'search/:seriesId/:searchTerms', element: <SiteWideMaintenance><SearchPage /></SiteWideMaintenance> },
+        { path: 'favorites', element: <SiteWideMaintenance><FavoritesPage /></SiteWideMaintenance> },
         {
           path: 'v2',
-          element: <IpfsSearchBar />,
+          element: <SiteWideMaintenance><IpfsSearchBar /></SiteWideMaintenance>,
           children: [
             { path: 'search/:cid', element: <V2SearchPage /> },
             { path: 'search/:cid/:searchTerms', element: <V2SearchPage /> },
@@ -84,16 +86,16 @@ export default function Router() {
             { path: 'episode/:cid/:season/:episode/:frame', element: <V2EpisodePage /> },
           ]
         },
-        { path: 'frame/:fid', element: <TopBannerSearchRevised><FramePage /></TopBannerSearchRevised> },
-        { path: 'editor/:fid', element: <TopBannerSearchRevised><EditorPage /></TopBannerSearchRevised> },
-        { path: 'series/:seriesId', element: <TopBannerSearchRevised><SeriesPage /></TopBannerSearchRevised> },
-        { path: '/episode/:seriesId/:seasonNum/:episodeNum', element: <TopBannerSearchRevised><EpisodePage /></TopBannerSearchRevised> },
-        { path: '/episode/:seriesId/:seasonNum/:episodeNum/:frameNum', element: <TopBannerSearchRevised><EpisodePage /></TopBannerSearchRevised> },
-        { path: '/vote', element: <TopBannerSearchRevised><VotingPage /></TopBannerSearchRevised> },
-        { path: '/contribute', element: <ContributorRequest /> },
-        { path: '/pricing', element: <PricingPage /> },
-        { path: '/:seriesId', element: <DynamicRouteHandler /> },
-        { path: '/server', element: <ServerPage /> }
+        { path: 'frame/:fid', element: <SiteWideMaintenance><TopBannerSearchRevised><FramePage /></TopBannerSearchRevised></SiteWideMaintenance> },
+        { path: 'editor/:fid', element: <SiteWideMaintenance><TopBannerSearchRevised><EditorPage /></TopBannerSearchRevised></SiteWideMaintenance> },
+        { path: 'series/:seriesId', element: <SiteWideMaintenance><TopBannerSearchRevised><SeriesPage /></TopBannerSearchRevised></SiteWideMaintenance> },
+        { path: '/episode/:seriesId/:seasonNum/:episodeNum', element: <SiteWideMaintenance><TopBannerSearchRevised><EpisodePage /></TopBannerSearchRevised></SiteWideMaintenance> },
+        { path: '/episode/:seriesId/:seasonNum/:episodeNum/:frameNum', element: <SiteWideMaintenance><TopBannerSearchRevised><EpisodePage /></TopBannerSearchRevised></SiteWideMaintenance> },
+        { path: '/vote', element: <SiteWideMaintenance><TopBannerSearchRevised><VotingPage /></TopBannerSearchRevised></SiteWideMaintenance> },
+        { path: '/contribute', element: <SiteWideMaintenance><ContributorRequest /></SiteWideMaintenance> },
+        { path: '/pricing', element: <SiteWideMaintenance><PricingPage /></SiteWideMaintenance> },
+        { path: '/:seriesId', element: <SiteWideMaintenance><DynamicRouteHandler /></SiteWideMaintenance> },
+        { path: '/server', element: <SiteWideMaintenance><ServerPage /></SiteWideMaintenance> }
       ]
     },
     {
@@ -140,7 +142,7 @@ export default function Router() {
     },
     {
       path: '/section/:sectionIndex',
-      element: <HomePage />
+      element: <SiteWideMaintenance><HomePage /></SiteWideMaintenance>
     },
     {
       path: '/privacypolicy',

--- a/src/sections/@dashboard/website-settings/MaintenanceModes.js
+++ b/src/sections/@dashboard/website-settings/MaintenanceModes.js
@@ -1,0 +1,77 @@
+import { Save } from '@mui/icons-material';
+import { LoadingButton } from '@mui/lab';
+import { Card, FormControlLabel, FormGroup, Grid, Stack, Switch, Typography } from '@mui/material';
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+
+export default function MaintenanceModes({
+    currentSettings,
+    saveFunction = () => {},
+    saving,
+    fullSiteMaintenance,
+    setFullSiteMaintenance,
+    universalSearchMaintenance,
+    setUniversalSearchMaintenance,
+}) {
+
+
+    return (
+        <Grid container spacing={3}>
+            <Grid item xs={12} md={4}>
+                <Typography fontSize={24} fontWeight={700}>
+                    Maintenance Modes
+                </Typography>
+                <Typography fontSize={14} fontWeight={500}>
+                    Disable features or the entire website
+                </Typography>
+            </Grid>
+            <Grid item xs={12} md={8}>
+                <Card sx={{ p: 2 }} variant='outlined'>
+                    <Stack spacing={2}>
+                        <FormGroup>
+                            <FormControlLabel
+                                control={
+                                    <Switch
+                                        disabled={saving}
+                                        checked={fullSiteMaintenance}
+                                        onChange={(event) => {
+                                            setFullSiteMaintenance(event.target.checked)
+                                        }}
+                                    />
+                                }
+                                label="Full Site Maintenance Mode"
+                            />
+                        </FormGroup>
+                        <FormGroup>
+                            <FormControlLabel
+                                control={
+                                    <Switch
+                                        disabled={saving}
+                                        checked={universalSearchMaintenance}
+                                        onChange={(event) => {
+                                            setUniversalSearchMaintenance(event.target.checked)
+                                        }}
+                                    />
+                                }
+                                label="Universal Search Maintenance Mode"
+                            />
+                        </FormGroup>
+                        <LoadingButton onClick={saveFunction} disabled={saving} startIcon={<Save />} variant='contained' loading={saving}>
+                            Save Changes
+                        </LoadingButton>
+                    </Stack>
+                </Card>
+            </Grid>
+        </Grid>
+    )
+}
+
+MaintenanceModes.propTypes = {
+    currentSettings: PropTypes.object,
+    saveFunction: PropTypes.func,
+    saving: PropTypes.bool,
+    fullSiteMaintenance: PropTypes.string,
+    setFullSiteMaintenance: PropTypes.func,
+    universalSearchMaintenance: PropTypes.string,
+    setUniversalSearchMaintenance: PropTypes.func,
+}


### PR DESCRIPTION
This PR adds an admin settings page for setting site wide maintenance mode and universal search maintenance mode.

I've included a wrapper for the site wide maintenance that will still allow us to get to the proper pages to log in and turn it off.

I've also added a comment to the memesrcSearchV2 function so that it will update with the merge.

TODO: I still need to add the popup for the search results page when trying to do a universal search if it is in maintenance mode.