### PR TITLE
Routes and preloading

### DIFF
--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -45,8 +45,8 @@ export default function SearchPage({ metadata }) {
 
     setV2SearchQuery(searchTerm)
     const encodedSearchTerms = encodeURI(searchTerm)
-    console.log(`Navigating to: '${`/v2/search/${seriesTitle}/${encodedSearchTerms}`}'`)
-    navigate(`/v2/search/${seriesTitle}/${encodedSearchTerms}`)
+    console.log(`Navigating to: '${`/search/${seriesTitle}/${encodedSearchTerms}`}'`)
+    navigate(`/search/${seriesTitle}/${encodedSearchTerms}`)
     // console.log(seriesTitle)
 
     // const v2 = shows?.find(obj => obj.id === seriesTitle) || savedCids?.find(obj => obj.id === seriesTitle)

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -176,7 +176,7 @@ export default function SearchPage() {
     }
     const encodedSearchTerms = encodeURI(searchTerm)
     setSearchQuery(searchTerm)
-    navigate(`/v2/search/${seriesTitle}/${encodedSearchTerms}`)
+    navigate(`/search/${seriesTitle}/${encodedSearchTerms}`)
   }, [seriesTitle, searchTerm, navigate]);
 
   return (

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -482,11 +482,17 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
       resizeCanvas(desiredWidth, desiredHeight)
       editor?.canvas.setBackgroundImage(oImg);
       // if (defaultSubtitle) {
-      addText(defaultSubtitle || '')
+      // addText(defaultSubtitle || '')
       // }
       setImageLoaded(true)
     }
-  }, [defaultFrame, defaultSubtitle])
+  }, [defaultFrame])
+
+  useEffect(() => {
+    if (defaultSubtitle) {
+      addText(defaultSubtitle || '')
+    }
+  }, [defaultSubtitle]);
 
   // Calculate the desired editor size
   const calculateEditorSize = (aspectRatio) => {
@@ -565,7 +571,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
   const handleEdit = (event, index) => {
     // console.log(event)
     // console.log(index)
-    setDefaultSubtitle(event.target.value)
+    // setDefaultSubtitle(event.target.value)
     editor.canvas.item(index).set('text', event.target.value);
     // console.log(`Length of object:  + ${selectedObjects.length}`)
     setCanvasObjects([...editor.canvas._objects])

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -1141,7 +1141,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
   };
 
   const handleNavigate = (cid, season, episode, frame) => {
-    navigate(`/v2/editor/${cid}/${season}/${episode}/${frame}`);
+    navigate(`/editor/${cid}/${season}/${episode}/${frame}`);
     setOpenNavWithoutSavingDialog(false);
     editor.canvas.discardActiveObject().requestRenderAll();
     setFutureStates([]);
@@ -1865,7 +1865,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                           src={`${surroundingFrame.frameImage}`}
                           title={surroundingFrame.subtitle || 'No subtitle'}
                           onClick={() => {
-                            navigate(`/v2/frame/${cid}/${season}/${episode}/${surroundingFrame.frame}`);
+                            navigate(`/frame/${cid}/${season}/${episode}/${surroundingFrame.frame}`);
                           }}
                         />
                       </StyledCard>
@@ -1880,7 +1880,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                 <Button
                   variant="contained"
                   fullWidth
-                  href={`/v2/episode/${cid}/${season}/${episode}/${frame}`}
+                  href={`/episode/${cid}/${season}/${episode}/${frame}`}
                 >
                   View Episode
                 </Button>

--- a/src/pages/V2EpisodePage.js
+++ b/src/pages/V2EpisodePage.js
@@ -80,7 +80,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
   const navigateFrames = (direction) => {
     const currentFrame = parseInt(frame, 10);
     const newFrame = direction === 'prev' ? Math.max(currentFrame - fps * 10, 0) : currentFrame + fps * 10;
-    navigate(`/v2/episode/${cid}/${season}/${episode}/${newFrame}`);
+    navigate(`/episode/${cid}/${season}/${episode}/${newFrame}`);
   };
 
   return (
@@ -103,7 +103,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
             {results.map((result) => (
               <Grid item xs={12} key={result.fid}>
                 <div style={{ display: 'flex', justifyContent: 'center' }}>
-                  <Card component="a" href={`/v2/frame/${cid}/${season}/${episode}/${result.fid}`} style={{ display: 'flex', textDecoration: 'none', width: '100%' }}>
+                  <Card component="a" href={`/frame/${cid}/${season}/${episode}/${result.fid}`} style={{ display: 'flex', textDecoration: 'none', width: '100%' }}>
                     <CardMedia
                       component="img"
                       style={{ width: '50%', objectFit: 'contain' }}

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -496,7 +496,7 @@ export default function FramePage({ shows = [] }) {
               margin: '-10px'
             }}
             onClick={() => {
-              navigate(`/v2/frame/${cid}/${season}/${episode}/${Number(frame) - 10}`)
+              navigate(`/frame/${cid}/${season}/${episode}/${Number(frame) - 10}`)
             }}
           >
             <ArrowBackIos style={{ fontSize: '2rem' }} />
@@ -514,7 +514,7 @@ export default function FramePage({ shows = [] }) {
               margin: '-10px'
             }}
             onClick={() => {
-              navigate(`/v2/frame/${cid}/${season}/${episode}/${Number(frame) + 10}`)
+              navigate(`/frame/${cid}/${season}/${episode}/${Number(frame) + 10}`)
             }}
           >
             <ArrowForwardIos style={{ fontSize: '2rem' }} />
@@ -596,7 +596,7 @@ export default function FramePage({ shows = [] }) {
               size='small'
               icon={<OpenInNew />}
               label={`Season ${season} / Episode ${episode}`}
-              onClick={() => navigate(`/v2/episode/${cid}/${season}/${episode}/1`)}
+              onClick={() => navigate(`/episode/${cid}/${season}/${episode}/1`)}
               sx={{
                 marginBottom: '15px',
                 "& .MuiChip-label": {
@@ -609,7 +609,7 @@ export default function FramePage({ shows = [] }) {
               icon={<BrowseGallery />}
               // TODO: I'm assuming there's probably some easy math to put the time code here
               label={`${frameToTimeCode(frame)}`}
-              onClick={() => navigate(`/v2/episode/${cid}/${season}/${episode}/${frame}`)}
+              onClick={() => navigate(`/episode/${cid}/${season}/${episode}/${frame}`)}
               sx={{
                 marginBottom: '15px',
                 marginLeft: '5px',
@@ -845,7 +845,7 @@ export default function FramePage({ shows = [] }) {
               size="medium"
               fullWidth
               variant="contained"
-              to={`/v2/editor/${cid}/${season}/${episode}/${frame}`}
+              to={`/editor/${cid}/${season}/${episode}/${frame}`}
               component={RouterLink}
               sx={{ my: 2, backgroundColor: '#4CAF50', '&:hover': { backgroundColor: '#45a045' } }}
               startIcon={<Edit />}
@@ -890,7 +890,7 @@ export default function FramePage({ shows = [] }) {
                                     },
                                   },
                                 }}
-                                onClick={() => navigate(`/v2/frame/${cid}/${season}/${episode}/${result?.frame}`)}
+                                onClick={() => navigate(`/frame/${cid}/${season}/${episode}/${result?.frame}`)}
                               >
                                 {loading ? (
                                   <CircularProgress size={20} sx={{ color: '#565656' }} />
@@ -995,7 +995,7 @@ export default function FramePage({ shows = [] }) {
                           src={`${surroundingFrame.frameImage}`}
                           title={surroundingFrame.subtitle || 'No subtitle'}
                           onClick={() => {
-                            navigate(`/v2/frame/${cid}/${season}/${episode}/${surroundingFrame.frame}`);
+                            navigate(`/frame/${cid}/${season}/${episode}/${surroundingFrame.frame}`);
                           }}
                         />
                       </StyledCard>
@@ -1012,7 +1012,7 @@ export default function FramePage({ shows = [] }) {
               <Button
                 variant="contained"
                 fullWidth
-                href={`/v2/episode/${cid}/${season}/${episode}/${frame}`}
+                href={`/episode/${cid}/${season}/${episode}/${frame}`}
               >
                 View Episode
               </Button>

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -168,128 +168,128 @@ export default function FramePage({ shows = [] }) {
 
 
   const updateCanvasUnthrottled = (scaleDown) => {
-  const offScreenCanvas = document.createElement('canvas');
-  const ctx = offScreenCanvas.getContext('2d');
+    const offScreenCanvas = document.createElement('canvas');
+    const ctx = offScreenCanvas.getContext('2d');
 
-  const img = new Image();
-  img.crossOrigin = "anonymous";
-  img.src = displayImage;
-  img.onload = function () {
-    if (throttleTimeoutRef.current !== null) {
-      clearTimeout(throttleTimeoutRef.current);
-    }
-
-    throttleTimeoutRef.current = setTimeout(() => {
-      // Define the maximum width for the canvas
-      const maxCanvasWidth = 1000; // Adjust this value as needed
-
-      // Calculate the aspect ratio of the image
-      const canvasAspectRatio = img.width / img.height;
-
-      // Calculate the corresponding height for the maximum width
-      const maxCanvasHeight = maxCanvasWidth / canvasAspectRatio;
-
-      const referenceWidth = 1000;
-      const referenceFontSizeDesktop = 40;
-      const referenceFontSizeMobile = 40;
-      const referenceBottomAnch = 35;  // Reference distance from bottom for desktop
-      const referenceBottomAnchMobile = 35; // Reference distance for mobile
-
-      const scaleFactor = 1000 / referenceWidth;
-
-      const scaledFontSizeDesktop = referenceFontSizeDesktop * scaleFactor;
-      const scaledFontSizeMobile = referenceFontSizeMobile * scaleFactor;
-      const scaledBottomAnch = isMd ? referenceBottomAnch * scaleFactor * fontBottomMarginScaleFactor : referenceBottomAnchMobile * scaleFactor * fontBottomMarginScaleFactor;
-      const referenceLineHeight = 50;
-      const scaledLineHeight = referenceLineHeight * scaleFactor * fontLineHeightScaleFactor * fontSizeScaleFactor;
-
-      // Set the canvas dimensions
-      offScreenCanvas.width = maxCanvasWidth;
-      offScreenCanvas.height = maxCanvasHeight;
-      // Scale the image and draw it on the canvas
-      ctx.drawImage(img, 0, 0, maxCanvasWidth, maxCanvasHeight);
-      setLoading(false)
-
-      if (showText) {
-        // Styling the text
-        ctx.font = `700 ${isMd ? `${scaledFontSizeDesktop * fontSizeScaleFactor}px` : `${scaledFontSizeMobile * fontSizeScaleFactor}px`} Arial`;
-        ctx.textAlign = 'center';
-        ctx.fillStyle = 'white';
-        ctx.strokeStyle = 'black';
-        ctx.lineWidth = 6;
-        ctx.lineJoin = 'round'; // Add this line to round the joints
-
-        const x = offScreenCanvas.width / 2;
-        const maxWidth = offScreenCanvas.width - 60; // leaving some margin
-        const lineHeight = 24; // adjust as per your requirements
-        const startY = offScreenCanvas.height - (2 * lineHeight); // adjust to position the text properly
-
-        const text = loadedSubtitle;
-
-        // Calculate number of lines without drawing
-        const numOfLines = wrapText(ctx, text, x, startY, maxWidth, scaledLineHeight, false);
-        const totalTextHeight = numOfLines * scaledLineHeight;  // Use scaled line height
-
-        // Adjust startY to anchor the text a scaled distance from the bottom
-        const startYAdjusted = offScreenCanvas.height - totalTextHeight - scaledBottomAnch + 40;
-
-        // Draw the text using the adjusted startY
-        wrapText(ctx, text, x, startYAdjusted, maxWidth, scaledLineHeight);
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.src = displayImage;
+    img.onload = function () {
+      if (throttleTimeoutRef.current !== null) {
+        clearTimeout(throttleTimeoutRef.current);
       }
 
-      if (scaleDown) {
-        // Create a second canvas
-        const scaledCanvas = document.createElement('canvas');
-        const scaledCtx = scaledCanvas.getContext('2d');
+      throttleTimeoutRef.current = setTimeout(() => {
+        // Define the maximum width for the canvas
+        const maxCanvasWidth = 1000; // Adjust this value as needed
 
-        // Calculate the scaled dimensions
-        const scaledWidth = offScreenCanvas.width / 3;
-        const scaledHeight = offScreenCanvas.height / 3;
+        // Calculate the aspect ratio of the image
+        const canvasAspectRatio = img.width / img.height;
 
-        // Set the scaled canvas dimensions
-        scaledCanvas.width = scaledWidth;
-        scaledCanvas.height = scaledHeight;
+        // Calculate the corresponding height for the maximum width
+        const maxCanvasHeight = maxCanvasWidth / canvasAspectRatio;
 
-        // Draw the full-size canvas onto the scaled canvas at the reduced size
-        scaledCtx.drawImage(offScreenCanvas, 0, 0, scaledWidth, scaledHeight);
+        const referenceWidth = 1000;
+        const referenceFontSizeDesktop = 40;
+        const referenceFontSizeMobile = 40;
+        const referenceBottomAnch = 35;  // Reference distance from bottom for desktop
+        const referenceBottomAnchMobile = 35; // Reference distance for mobile
 
-        // Use the scaled canvas to create the blob
-        scaledCanvas.toBlob((blob) => {
-          if (blob) {
-            // Create an object URL for the blob
-            const imageUrl = URL.createObjectURL(blob);
+        const scaleFactor = 1000 / referenceWidth;
 
-            // Use this object URL as the src for the image instead of a data URL
-            setImgSrc(imageUrl);
+        const scaledFontSizeDesktop = referenceFontSizeDesktop * scaleFactor;
+        const scaledFontSizeMobile = referenceFontSizeMobile * scaleFactor;
+        const scaledBottomAnch = isMd ? referenceBottomAnch * scaleFactor * fontBottomMarginScaleFactor : referenceBottomAnchMobile * scaleFactor * fontBottomMarginScaleFactor;
+        const referenceLineHeight = 50;
+        const scaledLineHeight = referenceLineHeight * scaleFactor * fontLineHeightScaleFactor * fontSizeScaleFactor;
 
-            // Optionally, revoke the object URL after the image has loaded to release memory
-            img.onload = () => {
-              URL.revokeObjectURL(imageUrl);
-            };
-          }
-        }, 'image/png');
-      } else {
-        // Instead of using toDataURL, convert the canvas to a blob
-        offScreenCanvas.toBlob((blob) => {
-          if (blob) {
-            // Create an object URL for the blob
-            const imageUrl = URL.createObjectURL(blob);
+        // Set the canvas dimensions
+        offScreenCanvas.width = maxCanvasWidth;
+        offScreenCanvas.height = maxCanvasHeight;
+        // Scale the image and draw it on the canvas
+        ctx.drawImage(img, 0, 0, maxCanvasWidth, maxCanvasHeight);
+        setLoading(false)
 
-            // Use this object URL as the src for the image instead of a data URL
-            setImgSrc(imageUrl);
+        if (showText) {
+          // Styling the text
+          ctx.font = `700 ${isMd ? `${scaledFontSizeDesktop * fontSizeScaleFactor}px` : `${scaledFontSizeMobile * fontSizeScaleFactor}px`} Arial`;
+          ctx.textAlign = 'center';
+          ctx.fillStyle = 'white';
+          ctx.strokeStyle = 'black';
+          ctx.lineWidth = 6;
+          ctx.lineJoin = 'round'; // Add this line to round the joints
 
-            // Optionally, revoke the object URL after the image has loaded to release memory
-            img.onload = () => {
-              URL.revokeObjectURL(imageUrl);
-            };
-          }
-        }, 'image/png'); // You can specify the image format
-      }
+          const x = offScreenCanvas.width / 2;
+          const maxWidth = offScreenCanvas.width - 60; // leaving some margin
+          const lineHeight = 24; // adjust as per your requirements
+          const startY = offScreenCanvas.height - (2 * lineHeight); // adjust to position the text properly
 
-      throttleTimeoutRef.current = null;
-    }, 100); // Adjust the debounce delay as needed
+          const text = loadedSubtitle;
+
+          // Calculate number of lines without drawing
+          const numOfLines = wrapText(ctx, text, x, startY, maxWidth, scaledLineHeight, false);
+          const totalTextHeight = numOfLines * scaledLineHeight;  // Use scaled line height
+
+          // Adjust startY to anchor the text a scaled distance from the bottom
+          const startYAdjusted = offScreenCanvas.height - totalTextHeight - scaledBottomAnch + 40;
+
+          // Draw the text using the adjusted startY
+          wrapText(ctx, text, x, startYAdjusted, maxWidth, scaledLineHeight);
+        }
+
+        if (scaleDown) {
+          // Create a second canvas
+          const scaledCanvas = document.createElement('canvas');
+          const scaledCtx = scaledCanvas.getContext('2d');
+
+          // Calculate the scaled dimensions
+          const scaledWidth = offScreenCanvas.width / 3;
+          const scaledHeight = offScreenCanvas.height / 3;
+
+          // Set the scaled canvas dimensions
+          scaledCanvas.width = scaledWidth;
+          scaledCanvas.height = scaledHeight;
+
+          // Draw the full-size canvas onto the scaled canvas at the reduced size
+          scaledCtx.drawImage(offScreenCanvas, 0, 0, scaledWidth, scaledHeight);
+
+          // Use the scaled canvas to create the blob
+          scaledCanvas.toBlob((blob) => {
+            if (blob) {
+              // Create an object URL for the blob
+              const imageUrl = URL.createObjectURL(blob);
+
+              // Use this object URL as the src for the image instead of a data URL
+              setImgSrc(imageUrl);
+
+              // Optionally, revoke the object URL after the image has loaded to release memory
+              img.onload = () => {
+                URL.revokeObjectURL(imageUrl);
+              };
+            }
+          }, 'image/jpeg', 0.9);
+        } else {
+          // Instead of using toDataURL, convert the canvas to a blob
+          offScreenCanvas.toBlob((blob) => {
+            if (blob) {
+              // Create an object URL for the blob
+              const imageUrl = URL.createObjectURL(blob);
+
+              // Use this object URL as the src for the image instead of a data URL
+              setImgSrc(imageUrl);
+
+              // Optionally, revoke the object URL after the image has loaded to release memory
+              img.onload = () => {
+                URL.revokeObjectURL(imageUrl);
+              };
+            }
+          }, 'image/jpeg', 0.9); // You can specify the image format
+        }
+
+        throttleTimeoutRef.current = null;
+      }, 10); // Adjust the debounce delay as needed
+    };
   };
-};
 
   const updateCanvas = () => {
     if (throttleTimeoutRef.current === null) {
@@ -395,7 +395,17 @@ export default function FramePage({ shows = [] }) {
   const loadFineTuningFrames = async () => {
     try {
       // Since fetchFramesFineTuning now expects an array, calculate the array of indexes for fine-tuning
-      const fineTuningFrames = await fetchFramesFineTuning(confirmedCid, season, episode, frame);
+      const fineTuningImageUrls = await fetchFramesFineTuning(confirmedCid, season, episode, frame);
+
+      // Preload the images and convert them to blob URLs
+      const fineTuningFrames = await Promise.all(
+        fineTuningImageUrls.map(async (url) => {
+          const response = await fetch(url);
+          const blob = await response.blob();
+          return URL.createObjectURL(blob);
+        })
+      );
+
       setFineTuningFrames(fineTuningFrames);
       setFrames(fineTuningFrames);
       console.log("Fine Tuning Frames: ", fineTuningFrames);

--- a/src/pages/V2SearchPage.js
+++ b/src/pages/V2SearchPage.js
@@ -566,7 +566,7 @@ export default function SearchPage() {
             {newResults.slice(0, displayedResults).map((result, index) => (
               <Grid item xs={12} sm={6} md={3} key={index} className="result-item" data-result-index={index}>
                 <Link
-                  to={`/v2/frame/${cid}/${result.season}/${result.episode}/${Math.round(
+                  to={`/frame/${cid}/${result.season}/${result.episode}/${Math.round(
                     (parseInt(result.start_frame, 10) + parseInt(result.end_frame, 10)) / 2
                   )}`}
                   style={{ textDecoration: 'none' }}
@@ -675,7 +675,7 @@ export default function SearchPage() {
               <Grid item xs={12} key={show.id}>
                 <Card
                   onClick={() => {
-                    window.location.href = `/v2/search/${show.cid}/${params?.searchTerms || ''}`;
+                    window.location.href = `/search/${show.cid}/${params?.searchTerms || ''}`;
                   }}
                   sx={{
                     backgroundColor: show.colorMain,

--- a/src/routes.js
+++ b/src/routes.js
@@ -59,7 +59,7 @@ const WebsiteSettings = lazy(() => import('./pages/WebsiteSettings'))
 // ----------------------------------------------------------------------
 
 export default function Router() {
-   
+
 
   const routes = useRoutes([
     {
@@ -69,28 +69,33 @@ export default function Router() {
         { element: <SiteWideMaintenance><HomePage /></SiteWideMaintenance>, index: true },
         { path: 'search', element: <SiteWideMaintenance><Navigate to='/' /></SiteWideMaintenance> },
         { path: 'edit', element: <SiteWideMaintenance><EditorNewProjectPage /></SiteWideMaintenance> },
-        { path: 'editor/projects', element: <SiteWideMaintenance><EditorProjectsPage /></SiteWideMaintenance> },
-        { path: 'editor/new', element: <SiteWideMaintenance><EditorNewProjectPage /></SiteWideMaintenance> },
-        { path: 'editor/project/:editorProjectId', element: <SiteWideMaintenance><EditorPage /></SiteWideMaintenance> },
-        { path: 'search/:seriesId', element: <SiteWideMaintenance><SearchPage /></SiteWideMaintenance> },
-        { path: 'search/:seriesId/:searchTerms', element: <SiteWideMaintenance><SearchPage /></SiteWideMaintenance> },
+        // { path: 'editor/projects', element: <SiteWideMaintenance><EditorProjectsPage /></SiteWideMaintenance> },
+        // { path: 'editor/new', element: <SiteWideMaintenance><EditorNewProjectPage /></SiteWideMaintenance> },
+        // { path: 'editor/project/:editorProjectId', element: <SiteWideMaintenance><EditorPage /></SiteWideMaintenance> },
+        // { path: 'search/:seriesId', element: <SiteWideMaintenance><SearchPage /></SiteWideMaintenance> },
+        // { path: 'search/:seriesId/:searchTerms', element: <SiteWideMaintenance><SearchPage /></SiteWideMaintenance> },
+        { path: 'search/:cid', element: <SiteWideMaintenance><IpfsSearchBar><V2SearchPage /></IpfsSearchBar></SiteWideMaintenance> },
+        { path: 'search/:cid/:searchTerms', element: <SiteWideMaintenance><IpfsSearchBar><V2SearchPage /></IpfsSearchBar></SiteWideMaintenance> },
+        { path: 'frame/:cid/:season/:episode/:frame', element: <SiteWideMaintenance><IpfsSearchBar><V2FramePage /></IpfsSearchBar></SiteWideMaintenance> },
+        { path: 'editor/:cid/:season/:episode/:frame', element: <SiteWideMaintenance><IpfsSearchBar><V2EditorPage /></IpfsSearchBar></SiteWideMaintenance> },
+        { path: 'episode/:cid/:season/:episode/:frame', element: <SiteWideMaintenance><IpfsSearchBar><V2EpisodePage /></IpfsSearchBar></SiteWideMaintenance> },
         { path: 'favorites', element: <SiteWideMaintenance><FavoritesPage /></SiteWideMaintenance> },
-        {
-          path: 'v2',
-          element: <SiteWideMaintenance><IpfsSearchBar /></SiteWideMaintenance>,
-          children: [
-            { path: 'search/:cid', element: <V2SearchPage /> },
-            { path: 'search/:cid/:searchTerms', element: <V2SearchPage /> },
-            { path: 'frame/:cid/:season/:episode/:frame', element: <V2FramePage /> },
-            { path: 'editor/:cid/:season/:episode/:frame', element: <V2EditorPage /> },
-            { path: 'episode/:cid/:season/:episode/:frame', element: <V2EpisodePage /> },
-          ]
-        },
-        { path: 'frame/:fid', element: <SiteWideMaintenance><TopBannerSearchRevised><FramePage /></TopBannerSearchRevised></SiteWideMaintenance> },
-        { path: 'editor/:fid', element: <SiteWideMaintenance><TopBannerSearchRevised><EditorPage /></TopBannerSearchRevised></SiteWideMaintenance> },
+        // {
+        //   path: 'v2',
+        //   element: <SiteWideMaintenance><IpfsSearchBar /></SiteWideMaintenance>,
+        //   children: [
+        //     { path: 'search/:cid', element: <V2SearchPage /> },
+        //     { path: 'search/:cid/:searchTerms', element: <V2SearchPage /> },
+        //     { path: 'frame/:cid/:season/:episode/:frame', element: <V2FramePage /> },
+        //     { path: 'editor/:cid/:season/:episode/:frame', element: <V2EditorPage /> },
+        //     { path: 'episode/:cid/:season/:episode/:frame', element: <V2EpisodePage /> },
+        //   ]
+        // },
+        // { path: 'frame/:fid', element: <SiteWideMaintenance><TopBannerSearchRevised><FramePage /></TopBannerSearchRevised></SiteWideMaintenance> },
+        // { path: 'editor/:fid', element: <SiteWideMaintenance><TopBannerSearchRevised><EditorPage /></TopBannerSearchRevised></SiteWideMaintenance> },
         { path: 'series/:seriesId', element: <SiteWideMaintenance><TopBannerSearchRevised><SeriesPage /></TopBannerSearchRevised></SiteWideMaintenance> },
-        { path: '/episode/:seriesId/:seasonNum/:episodeNum', element: <SiteWideMaintenance><TopBannerSearchRevised><EpisodePage /></TopBannerSearchRevised></SiteWideMaintenance> },
-        { path: '/episode/:seriesId/:seasonNum/:episodeNum/:frameNum', element: <SiteWideMaintenance><TopBannerSearchRevised><EpisodePage /></TopBannerSearchRevised></SiteWideMaintenance> },
+        // { path: '/episode/:seriesId/:seasonNum/:episodeNum', element: <SiteWideMaintenance><TopBannerSearchRevised><EpisodePage /></TopBannerSearchRevised></SiteWideMaintenance> },
+        // { path: '/episode/:seriesId/:seasonNum/:episodeNum/:frameNum', element: <SiteWideMaintenance><TopBannerSearchRevised><EpisodePage /></TopBannerSearchRevised></SiteWideMaintenance> },
         { path: '/vote', element: <SiteWideMaintenance><TopBannerSearchRevised><VotingPage /></TopBannerSearchRevised></SiteWideMaintenance> },
         { path: '/contribute', element: <SiteWideMaintenance><ContributorRequest /></SiteWideMaintenance> },
         { path: '/pricing', element: <SiteWideMaintenance><PricingPage /></SiteWideMaintenance> },

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -515,7 +515,7 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
   const searchCid = (e) => {
     e.preventDefault()
     setCidSearchQuery(searchTerm)
-    navigate(`/v2/search/${cid}/${encodeURIComponent(searchTerm)}`)
+    navigate(`/search/${cid}/${encodeURIComponent(searchTerm)}`)
     return false
   }
 

--- a/src/sections/search/TopBannerSeachRevised.js
+++ b/src/sections/search/TopBannerSeachRevised.js
@@ -103,8 +103,8 @@ export default function TopBannerSearchRevised(props) {
       e.preventDefault();
     }
     const encodedSearchTerms = encodeURI(searchQuery)
-    console.log(`Navigating to: '${`/v2/search/${show}/${encodedSearchTerms}`}'`)
-    navigate(`/v2/search/${show}/${encodedSearchTerms}`)
+    console.log(`Navigating to: '${`/search/${show}/${encodedSearchTerms}`}'`)
+    navigate(`/search/${show}/${encodedSearchTerms}`)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [show, searchQuery]);
 
@@ -161,7 +161,7 @@ export default function TopBannerSearchRevised(props) {
 
   const handleSelectSeries = (data) => {
 
-    navigate(`/v2/search/${data}/${encodeURIComponent(searchTerm || searchTerms)}`)
+    navigate(`/search/${data}/${encodeURIComponent(searchTerm || searchTerms)}`)
 
     // if (data?.addNew) {
     //   setAddNewCidOpen(true)

--- a/src/sections/search/TopBannerSearch.js
+++ b/src/sections/search/TopBannerSearch.js
@@ -135,7 +135,7 @@ export default function TopBannerSearch(props) {
 
   const handleSelectSeries = (data) => {
 
-    navigate(`/v2/search/${data}/${encodeURIComponent(searchTerm)}`)
+    navigate(`/search/${data}/${encodeURIComponent(searchTerm)}`)
 
     // if (data?.addNew) {
     //   setAddNewCidOpen(true)

--- a/src/sections/search/ipfs-search-bar.js
+++ b/src/sections/search/ipfs-search-bar.js
@@ -141,7 +141,7 @@ export default function IpfsSearchBar(props) {
   }, [cid]);
 
   const handleSelectSeries = (data) => {
-    navigate(`/v2/search/${data}/${encodeURIComponent(search)}`)
+    navigate(`/search/${data}/${encodeURIComponent(search)}`)
     // if (data?.addNew) {
     //   setAddNewCidOpen(true)
     // } else {
@@ -193,7 +193,7 @@ export default function IpfsSearchBar(props) {
   const searchFunction = (searchEvent) => {
     searchEvent?.preventDefault();
     console.log(search)
-    navigate(`/v2/search/${cid}/${encodeURIComponent(search)}`)
+    navigate(`/search/${cid}/${encodeURIComponent(search)}`)
     return false
   }
 
@@ -304,14 +304,14 @@ export default function IpfsSearchBar(props) {
       </StyledHeader>
       <Divider sx={{ mb: 2.5 }} />
 
-      {pathname.startsWith("/v2/frame") &&
+      {pathname.startsWith("/frame") &&
         <Container maxWidth='xl' disableGutters sx={{ px: 1 }}>
           <Box
             sx={{ width: '100%', px: 2 }}
           >
             <Link
               component={RouterLink}
-              to={search ? `/v2/search/${cid}/${search}` : "/"}
+              to={search ? `/search/${cid}/${search}` : "/"}
               sx={{
                 color: 'white',
                 textDecoration: 'none',
@@ -333,14 +333,14 @@ export default function IpfsSearchBar(props) {
             </Typography>
         </Container>
       }
-      {pathname.startsWith("/v2/editor") &&
+      {pathname.startsWith("/editor") &&
         <Container maxWidth='xl' disableGutters sx={{ px: 1 }}>
           <Box
             sx={{ width: '100%', px: 2 }}
           >
             <Link
               component={RouterLink}
-              to={search ? `/v2/frame/${cid}/${params?.season}/${params?.episode}/${params?.frame}` : "/"}
+              to={search ? `/frame/${cid}/${params?.season}/${params?.episode}/${params?.frame}` : "/"}
               sx={{
                 color: 'white',
                 textDecoration: 'none',
@@ -359,7 +359,7 @@ export default function IpfsSearchBar(props) {
           </Box>
         </Container>
       }
-      <Outlet />
+      {props.children}
       <StyledLeftFooter className="bottomBtn">
         <a href="https://forms.gle/8CETtVbwYoUmxqbi7" target="_blank" rel="noreferrer" style={{ color: 'white', textDecoration: 'none' }}>
           <Fab color="primary" aria-label="feedback" style={{ margin: "0 10px 0 0", backgroundColor: "black", zIndex: '1300' }} size='medium'>

--- a/src/utils/loadRandomFrame.js
+++ b/src/utils/loadRandomFrame.js
@@ -83,7 +83,7 @@ function useLoadRandomFrame() {
                 setShowObj(loadedShowSubtitles)
                 const randomSubtitle = getRandomIndex(loadedShowSubtitles);
                 setLoadingRandom(false)
-                navigate(`/v2/frame/${showObject.id}/${randomSubtitle.season}/${randomSubtitle.episode}/${findMidpoint(randomSubtitle.start_frame, randomSubtitle.end_frame)}`)
+                navigate(`/frame/${showObject.id}/${randomSubtitle.season}/${randomSubtitle.episode}/${findMidpoint(randomSubtitle.start_frame, randomSubtitle.end_frame)}`)
             } else {
                 const sessionId = await getSessionID();
                 const apiName = 'publicapi';


### PR DESCRIPTION
This PR updates routes to remove the /v2/ path and fixes frame and editor page bugs.

Notably, it enforces preloading of fine tuning frames before letting the user slide between them.

I also noticed chrome was still a little iffy when making changes on the current frame page. I found some differences in the code for the refactored page and implemented it on the current frame page. That immediately solved the issues and left them both running equally smooth.