### PR TITLE
Add pro support page and adjust nav styling

### DIFF
--- a/src/components/nav-section/NavSection.js
+++ b/src/components/nav-section/NavSection.js
@@ -25,7 +25,7 @@ export default function NavSection({ data = [], ...other }) {
           <List disablePadding sx={{ p: 1 }}>
             {data.filter(item => item.adminOnly === false).map((section, index) => (
               <Fragment key={section.sectionTitle}>
-                <Typography variant='body1' fontWeight={700} pl={2} mb={2} mt={index > 0 ? 5 : 0}>
+                <Typography variant='h4' fontWeight={700} pl={2} mb={1} mt={index > 0 ? 4 : 0}>
                   {section.sectionTitle}
                 </Typography>
                 {
@@ -43,7 +43,7 @@ export default function NavSection({ data = [], ...other }) {
           <List disablePadding sx={{ p: 1 }}>
             {data.map((section, index) => (
               <Fragment key={section.sectionTitle}>
-                <Typography variant='body1' fontWeight={700} pl={2} mb={2} mt={index > 0 ? 5 : 0}>
+                <Typography variant='h4' fontWeight={700} pl={2} mb={1} mt={index > 0 ? 4 : 0}>
                   {section.sectionTitle}
                 </Typography>
                 {

--- a/src/components/nav-section/NavSection.js
+++ b/src/components/nav-section/NavSection.js
@@ -25,7 +25,7 @@ export default function NavSection({ data = [], ...other }) {
           <List disablePadding sx={{ p: 1 }}>
             {data.filter(item => item.adminOnly === false).map((section, index) => (
               <Fragment key={section.sectionTitle}>
-                <Typography variant='h4' fontWeight={700} pl={2} mb={1} mt={index > 0 ? 4 : 0}>
+                <Typography variant='subtitle2' color='gray' fontWeight={700} pl={2} mb={1} mt={index > 0 ? 4 : 0}>
                   {section.sectionTitle}
                 </Typography>
                 {
@@ -43,7 +43,7 @@ export default function NavSection({ data = [], ...other }) {
           <List disablePadding sx={{ p: 1 }}>
             {data.map((section, index) => (
               <Fragment key={section.sectionTitle}>
-                <Typography variant='h4' fontWeight={700} pl={2} mb={1} mt={index > 0 ? 4 : 0}>
+                <Typography variant='subtitle2' color='gray' fontWeight={700} pl={2} mb={1} mt={index > 0 ? 4 : 0}>
                   {section.sectionTitle}
                 </Typography>
                 {

--- a/src/components/nav-section/NavSection.js
+++ b/src/components/nav-section/NavSection.js
@@ -25,7 +25,7 @@ export default function NavSection({ data = [], ...other }) {
           <List disablePadding sx={{ p: 1 }}>
             {data.filter(item => item.adminOnly === false).map((section, index) => (
               <Fragment key={section.sectionTitle}>
-                <Typography variant='body2' fontWeight={700} pl={2} mb={2} mt={index > 0 ? 5 : 0}>
+                <Typography variant='body1' fontWeight={700} pl={2} mb={2} mt={index > 0 ? 5 : 0}>
                   {section.sectionTitle}
                 </Typography>
                 {
@@ -43,7 +43,7 @@ export default function NavSection({ data = [], ...other }) {
           <List disablePadding sx={{ p: 1 }}>
             {data.map((section, index) => (
               <Fragment key={section.sectionTitle}>
-                <Typography variant='body2' fontWeight={700} pl={2} mb={2} mt={index > 0 ? 5 : 0}>
+                <Typography variant='body1' fontWeight={700} pl={2} mb={2} mt={index > 0 ? 5 : 0}>
                   {section.sectionTitle}
                 </Typography>
                 {
@@ -85,7 +85,7 @@ function NavItem({ item }) {
         >
           <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
 
-          <ListItemText disableTypography primary={title} />
+          <ListItemText sx={{fontSize:16}} disableTypography primary={title} />
 
           {info && info}
         </StyledNavItem>
@@ -105,7 +105,7 @@ function NavItem({ item }) {
         >
           <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
 
-          <ListItemText disableTypography primary={title} />
+          <ListItemText sx={{fontSize:16}} disableTypography primary={title} />
 
           {info && info}
         </StyledNavItem>

--- a/src/components/nav-section/NavSection.js
+++ b/src/components/nav-section/NavSection.js
@@ -85,7 +85,7 @@ function NavItem({ item }) {
         >
           <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
 
-          <ListItemText sx={{fontSize:16}} disableTypography primary={title} />
+          <ListItemText sx={{fontSize:18}} disableTypography primary={title} />
 
           {info && info}
         </StyledNavItem>
@@ -105,7 +105,7 @@ function NavItem({ item }) {
         >
           <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
 
-          <ListItemText sx={{fontSize:16}} disableTypography primary={title} />
+          <ListItemText sx={{fontSize:18}} disableTypography primary={title} />
 
           {info && info}
         </StyledNavItem>

--- a/src/contexts/SubscribeDialog.js
+++ b/src/contexts/SubscribeDialog.js
@@ -280,7 +280,7 @@ export const DialogProvider = ({ children }) => {
                       <SupportAgent sx={{ color: getTextColor() }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500}>
-                      Premium Support
+                      Pro Support
                     </Typography>
                   </Box>
                 </Grid>

--- a/src/layouts/dashboard/nav/config.js
+++ b/src/layouts/dashboard/nav/config.js
@@ -18,7 +18,7 @@ const navConfig = [
 
       {
         title: 'search',
-        path: '/search',
+        path: '/',
         externalLink: false,
         icon: <Search />,
       },

--- a/src/layouts/dashboard/nav/config.js
+++ b/src/layouts/dashboard/nav/config.js
@@ -1,5 +1,5 @@
 // component
-import { Article, CardGiftcard, Favorite, FolderShared, MapsUgc, Settings, Shield } from '@mui/icons-material';
+import { Article, Ballot, CardGiftcard, Edit, Favorite, FolderShared, MapsUgc, Search, Settings, Shield, SupportAgent, Upload } from '@mui/icons-material';
 import SvgColor from '../../../components/svg-color';
 
 // ----------------------------------------------------------------------
@@ -12,7 +12,7 @@ const isElectron = () => {
 
 const navConfig = [
   {
-    sectionTitle: 'General',
+    sectionTitle: 'Tools',
     adminOnly: false,
     items: [
 
@@ -20,25 +20,19 @@ const navConfig = [
         title: 'search',
         path: '/search',
         externalLink: false,
-        icon: icon('ic_menu_item'),
+        icon: <Search />,
       },
       {
         title: 'edit',
         path: '/edit',
         externalLink: false,
-        icon: icon('ic_file'),
+        icon: <Edit />,
       },
       {
-        title: 'Request',
+        title: 'Vote',
         path: '/vote',
         externalLink: false,
-        icon: icon('ic_kanban')
-      },
-      {
-        title: 'Contribute',
-        path: '/contribute',
-        externalLink: false,
-        icon: <FolderShared />
+        icon: <Ballot />
       },
       ...(isElectron() ? [{
         title: 'Server',
@@ -46,6 +40,24 @@ const navConfig = [
         externalLink: false,
         icon: <Settings />
       }] : [])
+    ]
+  },
+  {
+    sectionTitle: 'Contribute',
+    adminOnly: false,
+    items: [
+      {
+        title: 'upload',
+        path: '/contribute',
+        externalLink: false,
+        icon: <Upload />
+      },
+      {
+        title: 'Donate',
+        path: 'https://memesrc.com/donate',
+        externalLink: true,
+        icon: <Favorite />
+      }
     ]
   },
   {
@@ -59,11 +71,11 @@ const navConfig = [
         icon: <MapsUgc />
       },
       {
-        title: 'Donate',
-        path: 'https://memesrc.com/donate',
-        externalLink: true,
-        icon: <Favorite />
-      }
+        title: 'Pro Support',
+        path: '/support',
+        externalLink: false,
+        icon: <SupportAgent />,
+      },
     ]
   },
 

--- a/src/layouts/dashboard/nav/config.js
+++ b/src/layouts/dashboard/nav/config.js
@@ -61,20 +61,20 @@ const navConfig = [
     ]
   },
   {
-    sectionTitle: 'Support',
+    sectionTitle: 'Contact',
     adminOnly: false,
     items: [
-      {
-        title: 'Feedback',
-        path: 'https://forms.gle/8CETtVbwYoUmxqbi7',
-        externalLink: true,
-        icon: <MapsUgc />
-      },
       {
         title: 'Pro Support',
         path: '/support',
         externalLink: false,
         icon: <SupportAgent />,
+      },
+      {
+        title: 'Feedback',
+        path: 'https://forms.gle/8CETtVbwYoUmxqbi7',
+        externalLink: true,
+        icon: <MapsUgc />
       },
     ]
   },

--- a/src/pages/PremiumSupport.js
+++ b/src/pages/PremiumSupport.js
@@ -1,0 +1,176 @@
+import { useContext, useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { Typography, Container, Grid, Stack, TextField, Box, Button, Paper, Divider, FormControl, FormLabel, Card, CardContent, List, ListItem, ListItemText, IconButton, Checkbox, FormControlLabel } from '@mui/material';
+import { LoadingButton } from '@mui/lab';
+import { Link } from 'react-router-dom';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { UserContext } from '../UserContext';
+import { SnackbarContext } from '../SnackbarContext';
+import { useSubscribeDialog } from '../contexts/useSubscribeDialog';
+
+export default function PremiumSupport() {
+  const [loadingSubmitStatus, setLoadingSubmitStatus] = useState();
+  const { user } = useContext(UserContext);
+  const { setOpen, setMessage: setSnackbarMessage, setSeverity } = useContext(SnackbarContext);
+  const [messageInput, setMessageInput] = useState('');
+  const [emailConsent, setEmailConsent] = useState(false);
+  const { openSubscriptionDialog } = useSubscribeDialog();
+  const [messageError, setMessageError] = useState(false);
+  const [emailConsentError, setEmailConsentError] = useState(false);
+  const [formSubmitted, setFormSubmitted] = useState(false);
+
+  const authorized = user?.userDetails?.magicSubscription === 'true';
+
+  const validateForm = () => {
+    let isValid = true;
+
+    if (messageInput.trim() === '') {
+      setMessageError(true);
+      isValid = false;
+    } else {
+      setMessageError(false);
+    }
+
+    if (!emailConsent) {
+      setEmailConsentError(true);
+      isValid = false;
+    } else {
+      setEmailConsentError(false);
+    }
+
+    return isValid;
+  };
+
+  const submitSupportTicket = () => {
+    setFormSubmitted(true);
+    if (validateForm()) {
+      setLoadingSubmitStatus(true);
+      // TODO: Submit support ticket with message
+      alert('TODO: Submit support ticket');
+      setMessageInput('');
+      setEmailConsent(false);
+      setLoadingSubmitStatus(false);
+      setFormSubmitted(false);
+    }
+  };
+
+  const handleMessageChange = (e) => {
+    setMessageInput(e.target.value);
+    if (formSubmitted) {
+      setMessageError(false);
+    }
+  };
+
+  const handleEmailConsentChange = (e) => {
+    setEmailConsent(e.target.checked);
+    if (formSubmitted) {
+      setEmailConsentError(false);
+    }
+  };
+
+  return (
+    <>
+      <Helmet>
+        <title> Premium Support • memeSRC </title>
+      </Helmet>
+      <Container maxWidth="xl" sx={{ height: '100%' }}>
+        {!authorized ? (
+          <Grid container height="100%" justifyContent="center" alignItems="center">
+            <Grid item>
+              <Stack spacing={3} justifyContent="center">
+                <Typography variant="h3" textAlign="center">
+                  Premium&nbsp;Support
+                </Typography>
+                <Typography variant="body" textAlign="center">
+                  Premium support is available for Pro subscribers. <br /> Upgrade to Pro to access personalized assistance.
+                </Typography>
+              </Stack>
+              <center>
+                <LoadingButton
+                  onClick={openSubscriptionDialog}
+                  variant="contained"
+                  size="large"
+                  sx={{ mt: 5, fontSize: 17 }}
+                >
+                  Upgrade to Pro
+                </LoadingButton>
+              </center>
+              <Typography variant="body2" textAlign="center" style={{ opacity: 0.7 }}>
+                <br />
+                <br />
+                You can also submit general feedback using{' '}
+                <a href="https://forms.gle/8CETtVbwYoUmxqbi7" style={{ color: 'white' }} target="_blank" rel="noreferrer">
+                  this link
+                </a>.
+              </Typography>
+            </Grid>
+          </Grid>
+        ) : (
+          <Grid container justifyContent="center" mt={6}>
+            <Grid item xs={12} md={8} lg={6}>
+              <Typography variant="h2" gutterBottom mb={4}>
+                Need some help?
+              </Typography>
+              <Paper elevation={3} sx={{ p: 2 }}>
+                <Typography variant="subtitle1" gutterBottom mt={1} mb={2}>
+                  As a Pro subscriber, you get access to Premium&nbsp;Support. Send us a message and we'll get back to you asap:
+                </Typography>
+                <TextField
+                  label="Message"
+                  multiline
+                  rows={6}
+                  value={messageInput}
+                  onChange={handleMessageChange}
+                  fullWidth
+                  sx={{ mb: 2 }}
+                  error={formSubmitted && messageError}
+                  helperText={formSubmitted && messageError ? 'Message is required' : ''}
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={emailConsent}
+                      onChange={handleEmailConsentChange}
+                      color="primary"
+                      size="small"
+                    />
+                  }
+                  label={
+                    <Typography variant="subtitle2" style={{ fontWeight: 'bold' }}>
+                      It's okay to email me about this message and my account
+                    </Typography>
+                  }
+                />
+                {formSubmitted && emailConsentError && (
+                  <Typography variant="subtitle2" color="error">
+                    (required)
+                  </Typography>
+                )}
+                <LoadingButton
+                  loading={loadingSubmitStatus}
+                  onClick={submitSupportTicket}
+                  variant="contained"
+                  size="large"
+                  fullWidth
+                  sx={{ mt: 2 }}
+                >
+                  Submit
+                </LoadingButton>
+              </Paper>
+              <Card sx={{ mt: 5, px: 1 }}>
+                <CardContent>
+                  <Typography variant="h5" gutterBottom>
+                    Thanks for being a Pro!
+                  </Typography>
+                  <Typography variant="body1">
+                    We can't thank you enough for your support!
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          </Grid>
+        )}
+      </Container>
+    </>
+  );
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -56,6 +56,7 @@ const V2FramePage = lazy(() => import('./pages/V2FramePage'));
 const V2EditorPage = lazy(() => import('./pages/V2EditorPage'));
 const V2EpisodePage = lazy(() => import('./pages/V2EpisodePage'));
 const WebsiteSettings = lazy(() => import('./pages/WebsiteSettings'))
+const PremiumSupport = lazy(() => import('./pages/PremiumSupport'));
 
 // ----------------------------------------------------------------------
 
@@ -81,6 +82,7 @@ export default function Router() {
         { path: 'editor/:cid/:season/:episode/:frame', element: <SiteWideMaintenance><IpfsSearchBar><V2EditorPage /></IpfsSearchBar></SiteWideMaintenance> },
         { path: 'episode/:cid/:season/:episode/:frame', element: <SiteWideMaintenance><IpfsSearchBar><V2EpisodePage /></IpfsSearchBar></SiteWideMaintenance> },
         { path: 'favorites', element: <SiteWideMaintenance><FavoritesPage /></SiteWideMaintenance> },
+        { path: 'support', element: <SiteWideMaintenance><PremiumSupport /></SiteWideMaintenance> },
         // {
         //   path: 'v2',
         //   element: <SiteWideMaintenance><IpfsSearchBar /></SiteWideMaintenance>,


### PR DESCRIPTION
# Description 

This PR adds a **Pro Support** page with a form gated by an active Pro subscription and changes related "Premium Support" phrasing to match. It also adjusts the nav bar icons, order, spacing, etc.

# Notes

Submissions from the Pro Support page is still placeholder. The form has validation, etc. but it just shows a "TODO" alert instead of submitting it. I figure we can decide what's best and add this functionality in a future PR. 

# Preview

### Pro Support Page

Unsubscribed vs. subscribed:

![9F99DCA6-7508-47DE-916E-AFBAB9F853DB](https://github.com/Vibe-House-LLC/memeSRC/assets/915285/e292150c-71b2-499f-90ba-e5f9d209be9c)


### Nav Bar Styling

The nav bar icons, sizing, spacing, order, etc. has been adjusted.

![IMG_7053](https://github.com/Vibe-House-LLC/memeSRC/assets/915285/042f5a27-50f2-48dc-bdf5-72823ff8a198)

