### PR TITLE
Add non-test stripe ids for pro subs

### DIFF
--- a/amplify/backend/function/memesrcPublicStripeFunction/src/index.js
+++ b/amplify/backend/function/memesrcPublicStripeFunction/src/index.js
@@ -22,11 +22,16 @@ const aws = require('aws-sdk');
 const { LambdaClient, InvokeCommand } = require("@aws-sdk/client-lambda");
 
 const creditsPerPrice = {
-  "price_1NbXguAqFX20vifI34N1MJFO": 69,  // Magic 69 (prod)
-  "price_1Nhc9UAqFX20vifI0mYIzSfs": 69,  // Magic 69 (dev)
+  // Beta Prices (non-test mode on stripe)
+  "price_1OziYeAqFX20vifIptXDlka4": 5,   // Pro 5 (beta)
+  "price_1OziZIAqFX20vifIQ5mw6jqr": 25,  // Pro 25 (beta)
+  "price_1Ozia3AqFX20vifIgwvdxsEg": 69,  // Pro 69 (beta)
+  "price_1NbXguAqFX20vifI34N1MJFO": 69,  // Magic 69 (beta) - deprecated
+  // Dev Prices (test mode on stripe)
   "price_1OyLVZAqFX20vifImSa8wizl": 5,   // Pro 5 (dev)
   "price_1OyLWrAqFX20vifIkrK4Oxnp": 25,  // Pro 25 (dev)
-  "price_1OyLXpAqFX20vifIxTi2SMIx": 69   // Pro 69 (dev)
+  "price_1OyLXpAqFX20vifIxTi2SMIx": 69,  // Pro 69 (dev)
+  "price_1Nhc9UAqFX20vifI0mYIzSfs": 69,  // Magic 69 (dev) - deprecated
 };
 
 /**

--- a/amplify/backend/function/memesrcStripeCallback/src/index.js
+++ b/amplify/backend/function/memesrcStripeCallback/src/index.js
@@ -22,11 +22,16 @@ const aws = require('aws-sdk');
 const { LambdaClient, InvokeCommand } = require("@aws-sdk/client-lambda");
 
 const creditsPerPrice = {
-  "price_1NbXguAqFX20vifI34N1MJFO": 69,  // Magic 69 (prod)
-  "price_1Nhc9UAqFX20vifI0mYIzSfs": 69,  // Magic 69 (dev)
+  // Beta Prices (non-test mode on stripe)
+  "price_1OziYeAqFX20vifIptXDlka4": 5,   // Pro 5 (beta)
+  "price_1OziZIAqFX20vifIQ5mw6jqr": 25,  // Pro 25 (beta)
+  "price_1Ozia3AqFX20vifIgwvdxsEg": 69,  // Pro 69 (beta)
+  "price_1NbXguAqFX20vifI34N1MJFO": 69,  // Magic 69 (beta) - deprecated
+  // Dev Prices (test mode on stripe)
   "price_1OyLVZAqFX20vifImSa8wizl": 5,   // Pro 5 (dev)
   "price_1OyLWrAqFX20vifIkrK4Oxnp": 25,  // Pro 25 (dev)
-  "price_1OyLXpAqFX20vifIxTi2SMIx": 69   // Pro 69 (dev)
+  "price_1OyLXpAqFX20vifIxTi2SMIx": 69,  // Pro 69 (dev)
+  "price_1Nhc9UAqFX20vifI0mYIzSfs": 69,  // Magic 69 (dev) - deprecated
 };
 
 /**

--- a/amplify/backend/function/memesrcUserFunction/src/index.js
+++ b/amplify/backend/function/memesrcUserFunction/src/index.js
@@ -914,20 +914,15 @@ export const handler = async (event) => {
       console.log('stripeCustomerInfo')
       console.log(stripeCustomerInfo)
 
-      const creditsPerPrice = {
-        "price_1NbXguAqFX20vifI34N1MJFO": 69,  // Magic 69 (prod)
-        "price_1Nhc9UAqFX20vifI0mYIzSfs": 69,  // Magic 69 (dev)
-        "price_1OyLVZAqFX20vifImSa8wizl": 5,   // Pro 5 (dev)
-        "price_1OyLWrAqFX20vifIkrK4Oxnp": 25,  // Pro 25 (dev)
-        "price_1OyLXpAqFX20vifIxTi2SMIx": 69   // Pro 69 (dev)
-      };
-
       const priceMap = {
         "magic69-beta": "price_1NbXguAqFX20vifI34N1MJFO",
         "magic69-dev": "price_1Nhc9UAqFX20vifI0mYIzSfs",
         "pro5-dev": "price_1OyLVZAqFX20vifImSa8wizl",
         "pro25-dev": "price_1OyLWrAqFX20vifIkrK4Oxnp",
-        "pro69-dev": "price_1OyLXpAqFX20vifIxTi2SMIx"
+        "pro69-dev": "price_1OyLXpAqFX20vifIxTi2SMIx",
+        "pro5-beta": "price_1OziYeAqFX20vifIptXDlka4",  // Pro 5 (prod)
+        "pro25-beta": "price_1OziZIAqFX20vifIQ5mw6jqr",  // Pro 25 (prod)
+        "pro69-beta": "price_1Ozia3AqFX20vifIgwvdxsEg",  // Pro 69 (prod)
       }
 
       const priceKey = `${body.priceKey}-${process.env.ENV}`


### PR DESCRIPTION
This PR updates the 'price' mappings to include the non-test version from Stripe.