### PR TITLE
Improve search result relevance

### DIFF
--- a/amplify/backend/function/memesrcSearchV2/src/index.js
+++ b/amplify/backend/function/memesrcSearchV2/src/index.js
@@ -173,14 +173,28 @@ exports.handler = async (event) => {
                 });
                 
                 const searchTerms = decodedQuery.trim().toLowerCase().split(" ");
+                const nonSpecialQuery = decodedQuery.replace(/[^a-zA-Z0-9\s]/g, '').toLowerCase();
+                const nonSpecialSearchTerms = nonSpecialQuery.split(" ");
+
                 let results = [];
                 showObj.forEach((line) => {
                     let score = 0;
-                    if (line.subtitle_text && line.subtitle_text.toLowerCase().includes(decodedQuery)) {
+                    const subtitleText = line.subtitle_text ? line.subtitle_text.toLowerCase() : '';
+                    const nonSpecialSubtitle = subtitleText.replace(/[^a-zA-Z0-9\s]/g, '');
+
+                    if (subtitleText.includes(decodedQuery)) {
                         score += 10;
                     }
+                    if (nonSpecialSubtitle.includes(nonSpecialQuery)) {
+                        score += 5;
+                    }
                     searchTerms.forEach((term) => {
-                        if (line.subtitle_text && line.subtitle_text.toLowerCase().includes(term)) {
+                        if (subtitleText.includes(term)) {
+                            score += 1;
+                        }
+                    });
+                    nonSpecialSearchTerms.forEach((term) => {
+                        if (nonSpecialSubtitle.includes(term)) {
                             score += 1;
                         }
                     });
@@ -188,7 +202,7 @@ exports.handler = async (event) => {
                         results.push({ ...line, score, cid: index });
                     }
                 });
-                
+
                 combinedResults = combinedResults.concat(results);
             }
             

--- a/amplify/backend/function/memesrcSearchV2/src/index.js
+++ b/amplify/backend/function/memesrcSearchV2/src/index.js
@@ -192,7 +192,14 @@ exports.handler = async (event) => {
                 combinedResults = combinedResults.concat(results);
             }
             
-            combinedResults.sort((a, b) => b.score - a.score);
+            combinedResults.sort((a, b) => {
+                if (b.score === a.score) {
+                    // If scores are the same, sort by subtitle length in ascending order
+                    return a.subtitle_text.length - b.subtitle_text.length;
+                }
+                // If scores are different, sort by score in descending order
+                return b.score - a.score;
+            });
             combinedResults = combinedResults.slice(0, 150);
             
             return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/pages/V2SearchPage.js
+++ b/src/pages/V2SearchPage.js
@@ -381,7 +381,7 @@ export default function SearchPage() {
       setNewResults(null);
       setLoadingResults(true);
       setDisplayedResults(RESULTS_PER_PAGE / 2);
-      const searchTerm = params?.searchTerms.trim().toLowerCase();
+      const searchTerm = encodeURIComponent(params?.searchTerms.trim().toLowerCase());
       if (searchTerm === "") {
         console.log("Search term is empty.");
         return;


### PR DESCRIPTION
## Description

This PR improves relevance of search results by: 

- Add scoring for a version of the query with no special characters
- Add another sort condition (prefer shorter subtitles as score tiebreakers)

### Notes

I noticed the homepage search bar drops special characters (e.g. searching `hello?` leads to a search for `hello`) but I didn't immediately see a fix, so I left it unfixed for now. lol