### PR TITLE
Temporarily disable animated results and hide search banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/pages/V2SearchPage.js
+++ b/src/pages/V2SearchPage.js
@@ -203,10 +203,10 @@ export default function SearchPage() {
 
   // ===== Upgraded Index Banner States ===== 
   const [isBannerMinimized, setIsBannerMinimized] = useState(true);
-
-  const [animationsEnabled, setAnimationsEnabled] = useState(
-    localStorage.getItem('animationsEnabled') === 'true' || false
-  );
+  const [animationsEnabled, setAnimationsEnabled] = useState(false);
+  // const [animationsEnabled, setAnimationsEnabled] = useState(
+  //   localStorage.getItem('animationsEnabled') === 'true' || false
+  // );
   // ===== ===== ===== ===== ===== ===== ===== 
 
   const [universalSearchMaintenance, setUniversalSearchMaintenance] = useState(false);
@@ -444,7 +444,7 @@ export default function SearchPage() {
 
   return (
     <>
-      <Collapse in={showBanner}>
+      {/* <Collapse in={showBanner}>
         <UpgradedIndexBanner show={showBanner}>
           {showBanner && (
             <>
@@ -525,7 +525,7 @@ export default function SearchPage() {
             Settings
           </MinimizedBannerText>
         </MinimizedBanner>
-      )}
+      )} */}
       {user?.userDetails?.subscriptionStatus !== 'active' && (
         <Grid item xs={12} mt={2}>
           <center>

--- a/src/pages/V2SearchPage.js
+++ b/src/pages/V2SearchPage.js
@@ -202,9 +202,7 @@ export default function SearchPage() {
   const [loadingCsv, setLoadingCsv] = useState(false);
 
   // ===== Upgraded Index Banner States ===== 
-  const [isBannerMinimized, setIsBannerMinimized] = useState(
-    localStorage.getItem(`dismissedBanner`) === 'true' || true
-  );
+  const [isBannerMinimized, setIsBannerMinimized] = useState(true);
 
   const [animationsEnabled, setAnimationsEnabled] = useState(
     localStorage.getItem('animationsEnabled') === 'true' || false
@@ -221,7 +219,7 @@ export default function SearchPage() {
   const { showObj, setShowObj, cid } = useSearchDetailsV2();
   const [loadingResults, setLoadingResults] = useState(true);
   const [videoUrls, setVideoUrls] = useState({});
-  const [showBanner, setShowBanner] = useState(!isBannerMinimized);
+  const [showBanner, setShowBanner] = useState(false);
 
   const [autoplay, setAutoplay] = useState(true);
 
@@ -259,16 +257,16 @@ export default function SearchPage() {
     };
   }, [newResults, autoplay]);
 
-  const checkBannerDismissed = () => {
-    const dismissedBanner = localStorage.getItem(`dismissedBanner`);
-    if (dismissedBanner === 'true') {
-      setIsBannerMinimized(true);
-      setShowBanner(false);
-    } else {
-      setIsBannerMinimized(false);
-      setShowBanner(true);
-    }
-  };
+  // const checkBannerDismissed = () => {
+  //   const dismissedBanner = localStorage.getItem(`dismissedBanner`);
+  //   if (dismissedBanner === 'true') {
+  //     setIsBannerMinimized(true);
+  //     setShowBanner(false);
+  //   } else {
+  //     setIsBannerMinimized(false);
+  //     setShowBanner(true);
+  //   }
+  // };
 
   useEffect(() => {
     async function initialize(cid = null) {
@@ -280,7 +278,7 @@ export default function SearchPage() {
       setLoadingCsv(false);
       setShowObj([]);
 
-      checkBannerDismissed(selectedCid);
+      // checkBannerDismissed(selectedCid);
     }
 
     async function getMaintenanceMode() {
@@ -313,11 +311,11 @@ export default function SearchPage() {
     fetchData();
   }, [params.cid]);
 
-  useEffect(() => {
-    if (cid) {
-      checkBannerDismissed(cid);
-    }
-  }, [cid]);
+  // useEffect(() => {
+  //   if (cid) {
+  //     checkBannerDismissed(cid);
+  //   }
+  // }, [cid]);
 
   useEffect(() => {
     if (newResults) {
@@ -452,7 +450,7 @@ export default function SearchPage() {
             <>
               <UpgradedIndexText>Upgraded!</UpgradedIndexText>
               <UpgradedIndexSubtext>
-                You're testing '{cid}' on the new data model.{' '}
+                You're searching an upgraded index.{' '}
                 <a href="https://forms.gle/8CETtVbwYoUmxqbi7" target="_blank" rel="noopener noreferrer">
                   Report&nbsp;a&nbsp;problem
                 </a>


### PR DESCRIPTION
This PR temporarily disables the animated thumbnails in search results and hides the 'upgraded index' search banner.