### PR TITLE
Improve episode page navigation

### DIFF
--- a/src/pages/V2EpisodePage.js
+++ b/src/pages/V2EpisodePage.js
@@ -75,7 +75,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
         setLoading(true);
 
         const frameIndexes = [];
-        for (let i = 0; i < 300; i += 1) {
+        for (let i = 0; i < 180; i += 1) {
           frameIndexes.push(parseInt(frame, 10) + i * fps);
         }
 
@@ -111,7 +111,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
       : parseInt(currentFrame, 10) + fps;
   
     const frameIndexes = [];
-    const numFrames = direction === 'prev' ? 15 : 300;
+    const numFrames = direction === 'prev' ? 15 : 180;
     for (let i = 0; i < numFrames; i += 1) {
       frameIndexes.push(newFrame + i * fps);
     }

--- a/src/pages/V2EpisodePage.js
+++ b/src/pages/V2EpisodePage.js
@@ -2,7 +2,7 @@
 
 import { Buffer } from "buffer";
 import React, { useState, useEffect, useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { CircularProgress, Container, Typography, Card, CardMedia, CardContent, Button, Grid, useMediaQuery, Box, List, ListItem, ListItemAvatar, Avatar, ListItemText } from '@mui/material';
 import PropTypes from 'prop-types';
 import { extractVideoFrames } from '../utils/videoFrameExtractor';
@@ -34,6 +34,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
   const [lastNext, setLastNext] = useState(null);
   const fps = 10; // Frames per second
   const isMd = useMediaQuery(theme => theme.breakpoints.up('md'));
+  const navigate = useNavigate();
 
   useEffect(() => {
     getV2Metadata(cid).then(metadata => {
@@ -145,6 +146,10 @@ export default function V2EpisodePage({ setSeriesTitle }) {
     setLoadingMore(false);
   };
 
+  const skipToStart = () => {
+    navigate(`/episode/${cid}/${season}/${episode}/1`);
+  };
+
   return (
     <Container maxWidth="lg" style={{ paddingTop: '20px', paddingBottom: '20px' }}>
       <Typography
@@ -158,6 +163,15 @@ export default function V2EpisodePage({ setSeriesTitle }) {
         <span style={{ fontSize: '18px' }}>Season {season}, Episode {episode}</span>
       </Typography>
       <Box marginBottom="20px">
+        <Button
+          fullWidth
+          disabled={loading || loadingMore}
+          variant="contained"
+          onClick={skipToStart}
+          style={{ marginBottom: '16px', backgroundColor: '#1976d2', color: 'white', padding: '12px' }}
+        >
+          Skip to Start
+        </Button>
         <Button
           fullWidth
           disabled={loading || loadingMore}

--- a/src/pages/V2EpisodePage.js
+++ b/src/pages/V2EpisodePage.js
@@ -32,6 +32,8 @@ export default function V2EpisodePage({ setSeriesTitle }) {
   const [subtitles, setSubtitles] = useState([]);
   const [lastPrev, setLastPrev] = useState(null);
   const [lastNext, setLastNext] = useState(null);
+  const [firstFrame, setFirstFrame] = useState(1);
+  const [lastFrame, setLastFrame] = useState(null);
   const fps = 10; // Frames per second
   const isMd = useMediaQuery(theme => theme.breakpoints.up('md'));
   const navigate = useNavigate();
@@ -62,6 +64,12 @@ export default function V2EpisodePage({ setSeriesTitle }) {
             end_frame: parseInt(parts[5], 10),
           };
         });
+
+        if (parsedSubtitles.length > 0) {
+          const lastSubtitle = parsedSubtitles[parsedSubtitles.length - 5];
+          const lastFrameIndex = lastSubtitle.end_frame - 30;
+          setLastFrame(lastFrameIndex);
+        }
 
         setSubtitles(parsedSubtitles);
       };
@@ -150,6 +158,14 @@ export default function V2EpisodePage({ setSeriesTitle }) {
     navigate(`/episode/${cid}/${season}/${episode}/1`);
   };
 
+  const skipToEnd = () => {
+    if (subtitles.length > 0) {
+      const lastSubtitle = subtitles[subtitles.length - 5];
+      const lastFrameIndex = lastSubtitle.end_frame - 30;
+      navigate(`/episode/${cid}/${season}/${episode}/${lastFrameIndex}`);
+    }
+  };
+
   return (
     <Container maxWidth="lg" style={{ paddingTop: '20px', paddingBottom: '20px' }}>
       <Typography
@@ -163,15 +179,17 @@ export default function V2EpisodePage({ setSeriesTitle }) {
         <span style={{ fontSize: '18px' }}>Season {season}, Episode {episode}</span>
       </Typography>
       <Box marginBottom="20px">
-        <Button
-          fullWidth
-          disabled={loading || loadingMore}
-          variant="contained"
-          onClick={skipToStart}
-          style={{ marginBottom: '16px', backgroundColor: '#1976d2', color: 'white', padding: '12px' }}
-        >
-          Skip to Start
-        </Button>
+        {parseInt(frame, 10) > firstFrame && (
+          <Button
+            fullWidth
+            disabled={loading || loadingMore}
+            variant="contained"
+            onClick={skipToStart}
+            style={{ marginBottom: '16px', backgroundColor: '#1976d2', color: 'white', padding: '12px' }}
+          >
+            Skip to Start
+          </Button>
+        )}
         <Button
           fullWidth
           disabled={loading || loadingMore}
@@ -219,6 +237,17 @@ export default function V2EpisodePage({ setSeriesTitle }) {
         >
           {loadingMore ? 'Loading...' : 'Next Frames'}
         </Button>
+        {parseInt(frame, 10) < lastFrame && (
+          <Button
+            fullWidth
+            disabled={loading || loadingMore}
+            variant="contained"
+            onClick={skipToEnd}
+            style={{ marginTop: '16px', backgroundColor: '#1976d2', color: 'white', padding: '12px' }}
+          >
+            Skip to End
+          </Button>
+        )}
       </Box>
     </Container>
   );

--- a/src/pages/V2EpisodePage.js
+++ b/src/pages/V2EpisodePage.js
@@ -75,7 +75,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
         setLoading(true);
 
         const frameIndexes = [];
-        for (let i = 0; i < 60; i += 1) {
+        for (let i = 0; i < 300; i += 1) {
           frameIndexes.push(parseInt(frame, 10) + i * fps);
         }
 
@@ -111,7 +111,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
       : parseInt(currentFrame, 10) + fps;
   
     const frameIndexes = [];
-    const numFrames = direction === 'prev' ? 15 : 60;
+    const numFrames = direction === 'prev' ? 15 : 300;
     for (let i = 0; i < numFrames; i += 1) {
       frameIndexes.push(newFrame + i * fps);
     }


### PR DESCRIPTION
# Description

This PR improves episode page navigation by: 

- Increase items per page
- 'Skip to start' button
- 'Skip to end' button

### Notes

We still need to add something that stops items from showing after they've exceeded the highest valid index (which isn't quite trivial since we don't 'know' the last frame, so for now it'd need to rely on broken links or something lol)