### PR TITLE
Adjust configs to reduce cost

### DIFF
--- a/amplify/backend/function/frameExtractor/frameExtractor-cloudformation-template.json
+++ b/amplify/backend/function/frameExtractor/frameExtractor-cloudformation-template.json
@@ -86,7 +86,7 @@
           ]
         },
         "Runtime": "nodejs18.x",
-        "MemorySize": 2048,
+        "MemorySize": 768,
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/frameExtractor/src/index.js
+++ b/amplify/backend/function/frameExtractor/src/index.js
@@ -96,6 +96,7 @@ exports.handler = async (event) => {
         'Content-Type': 'image/jpeg',
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Headers': '*',
+        'Cache-Control': 'max-age=31536000',
       },
       body: base64Image,
       isBase64Encoded: true,

--- a/amplify/backend/function/memesrcSearchV2/memesrcSearchV2-cloudformation-template.json
+++ b/amplify/backend/function/memesrcSearchV2/memesrcSearchV2-cloudformation-template.json
@@ -133,7 +133,7 @@
           ]
         },
         "Runtime": "nodejs18.x",
-        "MemorySize": 2048,
+        "MemorySize": 256,
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -116,7 +116,7 @@
         },
         "frameExtractor": {
           "deploymentBucketName": "amplify-memesrc-dev-191629-deployment",
-          "s3Key": "amplify-builds/frameExtractor-4f4b6371424f5374534f-build.zip"
+          "s3Key": "amplify-builds/frameExtractor-4c6a446d6f6a5075726b-build.zip"
         },
         "memesrcSearchV2": {
           "deploymentBucketName": "amplify-memesrc-dev-191629-deployment",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/pages/V2EpisodePage.js
+++ b/src/pages/V2EpisodePage.js
@@ -246,7 +246,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
                 </Card>
               ) : (
                 <Card component="a" href={`/frame/${cid}/${season}/${episode}/${result.fid}`} style={{ textDecoration: 'none' }}>
-                  <Box sx={{ position: 'relative', paddingTop: '56.25%' }}>
+                  <Box sx={{ position: 'relative', paddingTop: '56.25%', backgroundColor: '#1f1f1f' }}>
                     <CardMedia
                       component="img"
                       image={result.frame_image}
@@ -262,7 +262,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
                         left: 0,
                         width: '100%',
                         height: '100%',
-                        objectFit: 'cover',
+                        objectFit: 'contain',
                         display: imagesLoaded[result.fid] ? 'block' : 'none',
                       }}
                     />
@@ -279,8 +279,8 @@ export default function V2EpisodePage({ setSeriesTitle }) {
                       />
                     )}
                   </Box>
-                  <CardContent sx={{ backgroundColor: '#1f1f1f', height: isMd ? 100 : 80 }}>
-                    <Typography variant="subtitle1" color="textPrimary" style={{ marginBottom: '8px' }}>
+                  <CardContent sx={{ backgroundColor: '#1f1f1f', padding: '16px' }}>
+                    <Typography variant="subtitle1" color="textPrimary" style={{ marginBottom: '8px', minHeight: '3em' }}>
                       {result.subtitle ? Buffer.from(result.subtitle, 'base64').toString() : '(...)'}
                     </Typography>
                     <Typography variant="caption" color="textSecondary">

--- a/src/pages/V2EpisodePage.js
+++ b/src/pages/V2EpisodePage.js
@@ -87,7 +87,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
         setLoading(true);
 
         const frameIndexes = [];
-        for (let i = 0; i < 250; i += 1) {
+        for (let i = 0; i < 60; i += 1) {
           frameIndexes.push(parseInt(frame, 10) + i * fps);
         }
 
@@ -123,7 +123,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
       : parseInt(currentFrame, 10) + fps;
   
     const frameIndexes = [];
-    const numFrames = direction === 'prev' ? 15 : 250;
+    const numFrames = direction === 'prev' ? 15 : 60;
     for (let i = 0; i < numFrames; i += 1) {
       frameIndexes.push(newFrame + i * fps);
     }
@@ -166,6 +166,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
       const lastSubtitle = subtitles[subtitles.length - 5];
       const lastFrameIndex = lastSubtitle.end_frame - 30;
       navigate(`/episode/${cid}/${season}/${episode}/${lastFrameIndex}`);
+      window.scrollTo(0, 0);
     }
   };
 

--- a/src/pages/V2EpisodePage.js
+++ b/src/pages/V2EpisodePage.js
@@ -3,7 +3,7 @@
 import { Buffer } from "buffer";
 import React, { useState, useEffect, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { CircularProgress, Container, Typography, Card, CardMedia, CardContent, Button, Grid, useMediaQuery, Box, List, ListItem, ListItemAvatar, Avatar, ListItemText } from '@mui/material';
+import { CircularProgress, Container, Typography, Card, CardMedia, CardContent, Button, Grid, useMediaQuery, Box, List, ListItem, ListItemAvatar, Avatar, ListItemText, Skeleton } from '@mui/material';
 import PropTypes from 'prop-types';
 import { extractVideoFrames } from '../utils/videoFrameExtractor';
 import { UserContext } from '../UserContext';
@@ -37,6 +37,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
   const [lastNext, setLastNext] = useState(null);
   const [firstFrame, setFirstFrame] = useState(1);
   const [lastFrame, setLastFrame] = useState(null);
+  const [imagesLoaded, setImagesLoaded] = useState({});
   const fps = 10; // Frames per second
   const isMd = useMediaQuery(theme => theme.breakpoints.up('md'));
   const navigate = useNavigate();
@@ -187,6 +188,10 @@ export default function V2EpisodePage({ setSeriesTitle }) {
   const adInterval = user?.userDetails?.subscriptionStatus !== 'active' ? 9 : Infinity;
   const resultsWithAds = injectAds(results, adInterval);
 
+  const handleImageLoad = (fid) => {
+    setImagesLoaded(prevState => ({ ...prevState, [fid]: true }));
+  };
+
   return (
     <Container maxWidth="lg" style={{ paddingTop: '20px', paddingBottom: '20px' }}>
       <Typography
@@ -229,7 +234,7 @@ export default function V2EpisodePage({ setSeriesTitle }) {
 
       {loading ? (
         <Box display="flex" justifyContent="center" marginTop="50px">
-          <CircularProgress />
+          <Skeleton variant="circular" width={40} height={40} />
         </Box>
       ) : (
         <Grid container spacing={2}>
@@ -241,12 +246,40 @@ export default function V2EpisodePage({ setSeriesTitle }) {
                 </Card>
               ) : (
                 <Card component="a" href={`/frame/${cid}/${season}/${episode}/${result.fid}`} style={{ textDecoration: 'none' }}>
-                  <CardMedia
-                    component="img"
-                    image={result.frame_image}
-                    alt={`Frame ${result.fid}`}
-                  />
-                  <CardContent sx={{backgroundColor: '#1f1f1f'}}>
+                  <Box sx={{ position: 'relative', paddingTop: '56.25%' }}>
+                    <CardMedia
+                      component="img"
+                      image={result.frame_image}
+                      alt={`Frame ${result.fid}`}
+                      onLoad={() => handleImageLoad(result.fid)}
+                      onError={() => {
+                        console.error(`Failed to load image for frame ${result.fid}`);
+                        handleImageLoad(result.fid);
+                      }}
+                      sx={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: '100%',
+                        height: '100%',
+                        objectFit: 'cover',
+                        display: imagesLoaded[result.fid] ? 'block' : 'none',
+                      }}
+                    />
+                    {!imagesLoaded[result.fid] && (
+                      <Skeleton
+                        variant="rectangular"
+                        sx={{
+                          position: 'absolute',
+                          top: 0,
+                          left: 0,
+                          width: '100%',
+                          height: '100%',
+                        }}
+                      />
+                    )}
+                  </Box>
+                  <CardContent sx={{ backgroundColor: '#1f1f1f', height: isMd ? 100 : 80 }}>
                     <Typography variant="subtitle1" color="textPrimary" style={{ marginBottom: '8px' }}>
                       {result.subtitle ? Buffer.from(result.subtitle, 'base64').toString() : '(...)'}
                     </Typography>


### PR DESCRIPTION
This PR attempts to address lambda costs by:

- Reducing the frame extractor memory.
- Increasing the `max-age` header for caching.
- Showing fewer items per page when browsing.

While I was in there, I also added loading skeletons while browsing.