### PR TITLE
Load fine tuning images upon interaction

### DIFF
--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -1179,7 +1179,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
   const [loadedEpisode, setLoadedEpisode] = useState('');
   const [surroundingSubtitles, setSurroundingSubtitles] = useState(null);
   const [loadingFineTuning, setLoadingFineTuning] = useState(false);
-  const [fineTuningFramesPreloaded, setFineTuningFramesPreloaded] = useState(false);
+  const [fineTuningLoadStarted, setFineTuningLoadStarted] = useState(false);
 
   useEffect(() => {
     getV2Metadata(cid).then(metadata => {
@@ -1317,7 +1317,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
       setSurroundingSubtitles([]);
       setSurroundingFrames(new Array(9).fill('loading'));
       setLoadingFineTuning(false)
-      setFineTuningFramesPreloaded(false)
+      setFineTuningLoadStarted(false)
 
       // Sequentially call the functions to ensure loading states and data fetching are managed efficiently
       loadInitialFrameInfo().then(() => {
@@ -1329,7 +1329,8 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
   }, [confirmedCid, season, episode, frame]);
 
   const loadFineTuningImages = () => {
-    if (fineTuningFrames && !fineTuningFramesPreloaded) {
+    if (fineTuningFrames && !fineTuningLoadStarted) {
+      setFineTuningLoadStarted(true)
       setLoadingFineTuning(true);
 
       // Create an array of promises for each image load
@@ -1344,7 +1345,6 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
       // Wait for all image promises to resolve
       Promise.all(imagePromises)
         .then(() => {
-          setFineTuningFramesPreloaded(true);
           setLoadingFineTuning(false);
         })
         .catch((error) => {

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -544,6 +544,23 @@ export default function FramePage({ shows = [] }) {
             image={imgSrc}
             id='frameImage'
           />
+          {loadingFineTuning && (
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <CircularProgress size={60} />
+            </div>
+          )}
           <IconButton
             style={{
               position: 'absolute',

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -89,7 +89,7 @@ export default function FramePage({ shows = [] }) {
   const [fontBottomMarginScaleFactor, setFontBottomMarginScaleFactor] = useState(1);
   const [enableFineTuningFrames, setEnableFineTuningFrames] = useState(true);
   const [loadingFineTuning, setLoadingFineTuning] = useState(false);
-  const [fineTuningFramesPreloaded, setFineTuningFramesPreloaded] = useState(false);
+  const [fineTuningLoadStarted, setFineTuningLoadStarted] = useState(false);
 
   const throttleTimeoutRef = useRef(null);
 
@@ -393,7 +393,7 @@ export default function FramePage({ shows = [] }) {
       setEnableFineTuningFrames(false)
       setImgSrc();
       setLoadingFineTuning(false)
-      setFineTuningFramesPreloaded(false)
+      setFineTuningLoadStarted(false)
 
       // Call the loading functions
       loadInitialFrameInfo().then(() => {
@@ -419,7 +419,8 @@ export default function FramePage({ shows = [] }) {
   };
 
   const loadFineTuningImages = () => {
-    if (fineTuningFrames && !fineTuningFramesPreloaded) {
+    if (fineTuningFrames && !fineTuningLoadStarted) {
+      setFineTuningLoadStarted(true)
       setLoadingFineTuning(true);
 
       // Create an array of promises for each image load
@@ -434,7 +435,6 @@ export default function FramePage({ shows = [] }) {
       // Wait for all image promises to resolve
       Promise.all(imagePromises)
         .then(() => {
-          setFineTuningFramesPreloaded(true);
           setLoadingFineTuning(false);
         })
         .catch((error) => {


### PR DESCRIPTION
This PR updates the fine tuning section on the frame page and editor page.

On the frame page, the fine tuning frames will not be loaded until the user touches/mouse downs on the slider. The icon changes to a loading spinner while the images are loading.

On the editor, the fine tuning frames preload when the user switches to the fine tuning tab. A linear progress bar will show up under the slider if the images are still loading. If the user has navigated to another frame but still has the slider open, it will wait to load the new fine tuning frame until they interact with the slider.

I also updated the sliders on the frame page to add text to the image on mobile by using the onTouchStart event alongside the mouseDown event.