### PR TITLE
Fix fine tuning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -1218,6 +1218,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
 
   const handleSliderChange = (newSliderValue) => {
     setSelectedFrameIndex(newSliderValue);
+    navigate(`/editor/${cid}/${season}/${episode}/${frame}/${newSliderValue}`)
     fabric.Image.fromURL(
       fineTuningBlobs[newSliderValue],
       (oImg) => {

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -80,7 +80,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
 
   // console.log(searchDetails.fineTuningFrame)
   // Get everything ready
-  const { fid, editorProjectId } = useParams();
+  const { fid, editorProjectId, fineTuningIndex } = useParams();
   const { user, setUser } = useContext(UserContext);
   const [defaultFrame, setDefaultFrame] = useState(null);
   const [pickingColor, setPickingColor] = useState(false);
@@ -1201,11 +1201,11 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
     if (frames && frames.length > 0) {
       console.log(frames.length)
       console.log(Math.floor(frames.length / 2))
-      setSelectedFrameIndex(selectedFrameIndex || Math.floor(frames.length / 2))
+      setSelectedFrameIndex(fineTuningIndex || Math.floor(frames.length / 2))
 
       // Background image from the given URL
       fabric.Image.fromURL(
-        selectedFrameIndex ? frames[selectedFrameIndex] : frames[Math.floor(frames.length / 2)],
+        fineTuningIndex ? frames[fineTuningIndex] : frames[Math.floor(frames.length / 2)],
         (oImg) => {
           setDefaultFrame(oImg);
           setDefaultSubtitle(loadedSubtitle);

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -537,6 +537,7 @@ useEffect(() => {
 
   const handleSliderChange = (newSliderValue) => {
     setSelectedFrameIndex(newSliderValue);
+    navigate(`/frame/${cid}/${season}/${episode}/${frame}/${newSliderValue}`)
     setDisplayImage(fineTuningBlobs?.[newSliderValue] || null);
   };
 

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -75,7 +75,7 @@ export default function FramePage({ shows = [] }) {
   const [surroundingFrames, setSurroundingFrames] = useState([]);
   const [surroundingSubtitles, setSurroundingSubtitles] = useState(null);
   const [loading, setLoading] = useState(false);
-  const { cid, season, episode, frame } = useParams();
+  const { cid, season, episode, frame, fineTuningIndex = null } = useParams();
   const [confirmedCid, setConfirmedCid] = useState();
   const [sliderValue, setSliderValue] = useState(fineTuningFrame || 0);
   const [displayImage, setDisplayImage] = useState();
@@ -530,8 +530,8 @@ useEffect(() => {
     if (frames && frames.length > 0) {
       console.log(frames.length)
       console.log(Math.floor(frames.length / 2))
-      setSelectedFrameIndex(selectedFrameIndex || Math.floor(frames.length / 2))
-      setDisplayImage(selectedFrameIndex ? frames[selectedFrameIndex] : frames[Math.floor(frames.length / 2)])
+      setSelectedFrameIndex(fineTuningIndex || Math.floor(frames.length / 2))
+      setDisplayImage(fineTuningIndex ? frames[fineTuningIndex] : frames[Math.floor(frames.length / 2)])
     }
   }, [frames]);
 
@@ -1082,7 +1082,7 @@ useEffect(() => {
               size="medium"
               fullWidth
               variant="contained"
-              to={`/editor/${cid}/${season}/${episode}/${frame}`}
+              to={`/editor/${cid}/${season}/${episode}/${frame}${(fineTuningIndex || fineTuningLoadStarted) ? `/${selectedFrameIndex}` : ''}`}
               component={RouterLink}
               sx={{ my: 2, backgroundColor: '#4CAF50', '&:hover': { backgroundColor: '#45a045' } }}
               startIcon={<Edit />}

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -414,7 +414,6 @@ export default function FramePage({ shows = [] }) {
 
       setFineTuningFrames(fineTuningImageUrls);
       setFrames(fineTuningImageUrls);
-      console.log("Fine Tuning Frames: ", fineTuningImageUrls);
     } catch (error) {
       console.error("Failed to fetch fine tuning frames:", error);
     }
@@ -454,6 +453,13 @@ export default function FramePage({ shows = [] }) {
         });
     }
   };
+
+useEffect(() => {
+  if (fineTuningBlobs && fineTuningBlobs.length > 0) {
+    setDisplayImage(fineTuningBlobs?.[selectedFrameIndex] || null);
+  }
+
+}, [fineTuningBlobs]);
 
 
   function frameToTimeCode(frame, frameRate = 10) {
@@ -518,7 +524,7 @@ export default function FramePage({ shows = [] }) {
 
   useEffect(() => {
     updateCanvasUnthrottled();
-  }, [displayImage, loadedSubtitle, frame]);
+  }, [displayImage, loadedSubtitle, frame, fineTuningBlobs, selectedFrameIndex]);
 
   useEffect(() => {
     if (frames && frames.length > 0) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -83,6 +83,8 @@ export default function Router() {
         { path: 'search/:cid/:searchTerms', element: <SiteWideMaintenance><IpfsSearchBar><V2SearchPage /></IpfsSearchBar></SiteWideMaintenance> },
         { path: 'frame/:cid/:season/:episode/:frame', element: <SiteWideMaintenance><IpfsSearchBar><V2FramePage /></IpfsSearchBar></SiteWideMaintenance> },
         { path: 'editor/:cid/:season/:episode/:frame', element: <SiteWideMaintenance><IpfsSearchBar><V2EditorPage /></IpfsSearchBar></SiteWideMaintenance> },
+        { path: 'frame/:cid/:season/:episode/:frame/:fineTuningIndex', element: <SiteWideMaintenance><IpfsSearchBar><V2FramePage /></IpfsSearchBar></SiteWideMaintenance> },
+        { path: 'editor/:cid/:season/:episode/:frame/:fineTuningIndex', element: <SiteWideMaintenance><IpfsSearchBar><V2EditorPage /></IpfsSearchBar></SiteWideMaintenance> },
         { path: 'episode/:cid/:season/:episode/:frame', element: <SiteWideMaintenance><IpfsSearchBar><V2EpisodePage /></IpfsSearchBar></SiteWideMaintenance> },
         { path: 'favorites', element: <SiteWideMaintenance><FavoritesPage /></SiteWideMaintenance> },
         { path: 'support', element: <SiteWideMaintenance><ProSupport /></SiteWideMaintenance> },

--- a/src/sections/search/ipfs-search-bar.js
+++ b/src/sections/search/ipfs-search-bar.js
@@ -357,7 +357,7 @@ export default function IpfsSearchBar(props) {
           >
             <Link
               component={RouterLink}
-              to={search ? `/frame/${params?.cid}/${params?.season}/${params?.episode}/${params?.frame}` : "/"}
+              to={`/frame/${params?.cid}/${params?.season}/${params?.episode}/${params?.frame}${selectedFrameIndex ? `/${selectedFrameIndex}` : ''}`}
               sx={{
                 color: 'white',
                 textDecoration: 'none',


### PR DESCRIPTION
This PR fixes a bug on the frame page where selecting a position on the fine tuning slider while the frames were still loading would not update the canvas once the frames have loaded.

It also adds two optional param paths to the editor and frame pages with a fineTuningIndex param. This carries over the selection from both pages, keeping the selected fine tuning frame in sync during navigation.