### PR TITLE
Frame slider hotfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.0.16",
+      "version": "2.0.17",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -1218,7 +1218,6 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
 
   const handleSliderChange = (newSliderValue) => {
     setSelectedFrameIndex(newSliderValue);
-    navigate(`/editor/${cid}/${season}/${episode}/${frame}/${newSliderValue}`)
     fabric.Image.fromURL(
       fineTuningBlobs[newSliderValue],
       (oImg) => {
@@ -1626,6 +1625,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                         onMouseDown={loadFineTuningImages}
                         onTouchStart={loadFineTuningImages}
                         onChange={(e, newValue) => handleSliderChange(newValue)}
+                        onChangeCommitted={(e, value) => {navigate(`/editor/${cid}/${season}/${episode}/${frame}/${value}`)}}
                         valueLabelFormat={(value) => `Fine Tuning: ${((value - 4) / 10).toFixed(1)}s`}
                         marks
                         disabled={loadingFineTuning}

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -537,7 +537,6 @@ useEffect(() => {
 
   const handleSliderChange = (newSliderValue) => {
     setSelectedFrameIndex(newSliderValue);
-    navigate(`/frame/${cid}/${season}/${episode}/${frame}/${newSliderValue}`)
     setDisplayImage(fineTuningBlobs?.[newSliderValue] || null);
   };
 
@@ -626,6 +625,7 @@ useEffect(() => {
               onMouseDown={loadFineTuningImages}
               onTouchStart={loadFineTuningImages}
               onChange={(e, newValue) => handleSliderChange(newValue)}
+              onChangeCommitted={(e, value) => {navigate(`/frame/${cid}/${season}/${episode}/${frame}/${value}`)}}
               valueLabelFormat={(value) => `Fine Tuning: ${((value - 4) / 10).toFixed(1)}s`}
               marks
               componentsProps={{


### PR DESCRIPTION
This PR fixes an issue caused by navigating to the fine tuning frame selection every time the value changes. It now only navigates after the user has finished moving the slider and let go of it via the onChangeCommitted callback of the slider.