### PR TITLE
Fix voting page errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.0.19",
+      "version": "2.0.20",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/pages/VotingPage.js
+++ b/src/pages/VotingPage.js
@@ -242,8 +242,8 @@ export default function VotingPage({ shows: searchableShows }) {
       console.log(voteData.lastBoost)
 
       const nextVoteTimes = {};
-      Object.keys(voteData.nextVoteTime).forEach((seriesId) => {
-        nextVoteTimes[seriesId] = voteData.nextVoteTime[seriesId];
+      Object.entries(voteData.nextVoteTime ?? {}).forEach(([seriesId, voteTime]) => {
+        nextVoteTimes[seriesId] = voteTime;
       });
       setNextVoteTimes(nextVoteTimes);  // assuming you have a state variable called nextVoteTimes
 

--- a/src/pages/VotingPage.js
+++ b/src/pages/VotingPage.js
@@ -594,7 +594,7 @@ export default function VotingPage({ shows: searchableShows }) {
                       // Insert the VotingPageAd component every 6 shows
                       (idx % 7) - 2 === 0 && idx !== 0 && user?.userDetails?.subscriptionStatus !== 'active'
                       ? (
-                        <Grid item xs={12} style={{ marginBottom: 15 }}>
+                        <Grid item xs={12} key={`ad-${idx}`} style={{ marginBottom: 15 }}>
                           <Card>
                             <CardContent>
                               <VotingPageAd />
@@ -967,7 +967,7 @@ export default function VotingPage({ shows: searchableShows }) {
             // Insert the VotingPageAd component every 6 shows
             user?.userDetails?.subscriptionStatus !== 'active'
             ? (
-              <Grid item xs={12} style={{ marginBottom: 15 }}>
+              <Grid item xs={12} key="footer-ad" style={{ marginBottom: 15 }}>
                 <Card>
                   <CardContent>
                     <VotingPageFooterAd />


### PR DESCRIPTION
# Description

This PR fixes some console errors on the [voting page](https://memesrc.com/vote): 

- Fixed a null item related error
- Added missing grid item keys

# Background 

There have been a couple recent reports of the voting page crashing on Android Chrome. This couldn't be reproduced in Desktop Chrome (and I can't test on Android), so I fixed a few console logs to see if it helps.