### PR TITLE
Add subscription management page

### DIFF
--- a/amplify/backend/function/memesrcUserFunction/src/index.js
+++ b/amplify/backend/function/memesrcUserFunction/src/index.js
@@ -1663,7 +1663,7 @@ export const handler = async (event) => {
 
         const updateUserDetailsQuery = `
           mutation updateUserDetails {
-            updateUserDetails(input: {id: "${userId}", subscriptionStatus: "failedPayment", credits: 0}) {
+            updateUserDetails(input: {id: "${userId}", subscriptionStatus: "failedPayment", credits: 0, magicSubscription: null}) {
               id
               credits
             }
@@ -2386,7 +2386,7 @@ export const handler = async (event) => {
       };
     }
   }
-  
+
 
   // console.log('THE RESPONSE: ', JSON.stringify(response));
 

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -85,7 +85,7 @@
         },
         "memesrcUserFunction": {
           "deploymentBucketName": "amplify-memesrc-dev-191629-deployment",
-          "s3Key": "amplify-builds/memesrcUserFunction-72564f67346b34664c74-build.zip",
+          "s3Key": "amplify-builds/memesrcUserFunction-683971426b61354c6644-build.zip",
           "secretsPathAmplifyAppId": "d32pnvtwxwtte5"
         },
         "memesrcVote": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.0.21",
+      "version": "2.0.22",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/magic-popup/MagicPopup.js
+++ b/src/components/magic-popup/MagicPopup.js
@@ -1,7 +1,7 @@
 import MuiAlert from '@mui/material/Alert';
 import PropTypes from 'prop-types';
 import { forwardRef, useContext, useEffect, useRef, useState } from 'react';
-import { Box, Chip, Divider, Fab, Popover, Stack, Typography, css, useTheme } from '@mui/material';
+import { Box, Button, Chip, Divider, Fab, Popover, Stack, Typography, css, useTheme } from '@mui/material';
 import { AutoFixHighRounded, Close, SupervisedUserCircle, Verified } from '@mui/icons-material';
 import { API } from 'aws-amplify';
 import { LoadingButton } from '@mui/lab';
@@ -21,6 +21,7 @@ MagicPopup.propTypes = {
 
 export default function MagicPopup({ children }) {
     const location = useLocation();
+    const navigate = useNavigate();
     const [magicToolsPopoverAnchorEl, setMagicToolsPopoverAnchorEl] = useState(null);
     const { user } = useContext(UserContext);
     const [loadingSubscriptionUrl, setLoadingSubscriptionUrl] = useState(false);
@@ -308,15 +309,15 @@ export default function MagicPopup({ children }) {
                 <Box width="100%" px={2} pb={2} pt={1}>
                     <>
                         {user?.userDetails?.magicSubscription === 'true' ? (
-                            <LoadingButton
+                            <Button
                                 loading={loadingSubscriptionUrl}
-                                onClick={logIntoCustomerPortal}
+                                onClick={() => { navigate('/manageSubscription'); setMagicToolsPopoverAnchorEl(); }}
                                 variant="contained"
                                 size="large"
                                 fullWidth
                             >
                                 Manage Subscription
-                            </LoadingButton>
+                            </Button>
                         ) : (
                             <>
                                 <LoadingButton

--- a/src/layouts/dashboard/header/AccountPopover.js
+++ b/src/layouts/dashboard/header/AccountPopover.js
@@ -166,7 +166,7 @@ export default function AccountPopover() {
                 {userDetails?.user?.userDetails?.magicSubscription === 'true' ?
                   <>
                   <Divider sx={{ borderStyle: 'dashed' }} />
-                    <MenuItem onClick={logIntoCustomerPortal} sx={{ m: 1 }}>
+                    <MenuItem onClick={() => { navigate('/manageSubscription'); handleClose(); }} sx={{ m: 1 }}>
                       <Stack direction='row' alignItems='center'>
                         {loadingCustomerPortal ? <><CircularProgress color='success' size={15} sx={{ mr: 1 }} /> Please Wait...</> : 'Manage Subscription'}
                       </Stack>

--- a/src/layouts/dashboard/nav/config.js
+++ b/src/layouts/dashboard/nav/config.js
@@ -1,5 +1,5 @@
 // component
-import { Article, Ballot, CardGiftcard, Edit, Favorite, FolderShared, MapsUgc, QuestionAnswer, Search, Settings, Shield, SupportAgent, Upload } from '@mui/icons-material';
+import { Article, Ballot, CardGiftcard, DocumentScanner, Edit, Favorite, FolderShared, MapsUgc, QuestionAnswer, Search, Settings, Shield, SupportAgent, Upload } from '@mui/icons-material';
 import SvgColor from '../../../components/svg-color';
 
 // ----------------------------------------------------------------------

--- a/src/pages/InvoicesListPage.js
+++ b/src/pages/InvoicesListPage.js
@@ -1,0 +1,241 @@
+import { useState, useEffect, useContext } from 'react';
+import { Box, Typography, Button, Container, LinearProgress, Chip, Card, Divider, Grid, Skeleton } from '@mui/material';
+import { DataGrid, GridOverlay } from '@mui/x-data-grid';
+import { API } from 'aws-amplify';
+import { Receipt } from '@mui/icons-material';
+import { LoadingButton } from '@mui/lab';
+import { UserContext } from '../UserContext';
+import { useSubscribeDialog } from '../contexts/useSubscribeDialog';
+
+const InvoiceListPage = () => {
+  const userDetails = useContext(UserContext);
+  const { openSubscriptionDialog } = useSubscribeDialog();
+  const [invoices, setInvoices] = useState([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [loadingSubscriptionUrl, setLoadingSubscriptionUrl] = useState(false);
+
+  const logIntoCustomerPortal = () => {
+    setLoadingSubscriptionUrl(true)
+    API.post('publicapi', '/user/update/getPortalLink', {
+      body: {
+        currentUrl: window.location.href
+      }
+    }).then(results => {
+      console.log(results)
+      setLoadingSubscriptionUrl(false)
+      window.location.href = results
+    }).catch(error => {
+      setLoadingSubscriptionUrl(false)
+      console.log(error.response)
+    })
+  }
+
+  useEffect(() => {
+    fetchInvoices();
+  }, [page]);
+
+  const fetchInvoices = async () => {
+    try {
+      setLoading(true);
+      const lastInvoiceId = invoices.length > 0 ? invoices[invoices.length - 1].id : null;
+      const response = await API.get('publicapi', '/user/update/listInvoices', {
+        ...(hasMore && { body: { lastInvoice: lastInvoiceId } }),
+      });
+      console.log(response);
+      setInvoices((prevInvoices) => [...prevInvoices, ...response.data]);
+      setHasMore(response.data.has_more);
+      setLoading(false);
+    } catch (error) {
+      console.error('Error fetching invoices:', error);
+      setLoading(false);
+    }
+  };
+
+  const handleLoadMore = () => {
+    setPage((prevPage) => prevPage + 1);
+  };
+
+  const openInvoicePDF = (url) => {
+    window.open(url, '_blank');
+  };
+
+  const columns = [
+    { field: 'number', headerName: 'Invoice Number', width: 200, headerClassName: 'header', cellClassName: 'cell' },
+    {
+      field: 'period',
+      headerName: 'Period',
+      width: 300,
+      headerClassName: 'header',
+      cellClassName: 'cell',
+      valueGetter: (params) =>
+        `${new Date(params.row.period_start * 1000).toLocaleDateString()} - ${new Date(
+          params.row.period_end * 1000
+        ).toLocaleDateString()}`,
+    },
+    {
+      field: 'status',
+      headerName: 'Status',
+      width: 150,
+      headerClassName: 'header',
+      cellClassName: 'cell',
+      renderCell: (params) => {
+        const status = params.value;
+        let cleanStatus = ''
+        let color = '';
+
+        if (status === 'paid') {
+          cleanStatus = 'Paid'
+          color = 'success';
+        } else if (status === 'open') {
+          cleanStatus = 'Attempt Made'
+          color = 'warning';
+        } else {
+          cleanStatus = status;
+          color = 'default';
+        }
+
+        return <Chip label={cleanStatus} color={color} />;
+      },
+    },
+    {
+      field: 'actions',
+      headerName: '',
+      flex: 1,
+      headerAlign: 'right',
+      align: 'right',
+      headerClassName: 'header',
+      cellClassName: 'cell',
+      renderCell: (params) => (
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => openInvoicePDF(params.row.invoice_pdf)}
+          disabled={!params.row.invoice_pdf}
+          startIcon={<Receipt />}
+        >
+          Download PDF
+        </Button>
+      ),
+    },
+  ];
+
+  const recentPaidInvoice = invoices.find((invoice) => invoice.paid);
+  const currentSubscription = recentPaidInvoice?.lines?.data?.[0]?.description
+    ?.replace(/^1\s*×\s*/, '')
+    ?.replace(/\s*\(memeSRC\)/i, '');
+
+  return (
+    <Container maxWidth="lg" sx={{ mt: 5 }}>
+      <Typography fontSize={37} fontWeight={700} gutterBottom>
+        Subscription Management
+      </Typography>
+      <Divider sx={{ my: 3 }} />
+
+      <Card sx={{ mb: 3, pb: 1 }}>
+        <Grid container alignItems='center'>
+          <Grid xs sx={{ p: 3 }}>
+            <Typography variant="h3">
+              Current Subscription
+            </Typography>
+            {userDetails?.user?.userDetails?.magicSubscription === 'true' ?
+              <>
+                {currentSubscription ? (
+                  <Typography fontSize={18} fontWeight={700}>{currentSubscription}</Typography>
+                ) : (
+                  <>
+                    {loading ? <LinearProgress sx={{ width: 300, py: 1, mt: 1.4 }} /> : <Typography>No current subscription found.</Typography>}
+                  </>
+                )}
+              </>
+              :
+              <Typography>No current subscription found.</Typography>
+            }
+
+          </Grid>
+          <Grid xs={12} md={4} sx={{ p: 3 }}>
+            {userDetails?.user?.userDetails?.magicSubscription === 'true' ? (
+              <LoadingButton
+                loading={loadingSubscriptionUrl}
+                onClick={() => { logIntoCustomerPortal(); }}
+                variant="contained"
+                size="large"
+                fullWidth
+              >
+                Manage Subscription
+              </LoadingButton>
+            ) : (
+              <>
+                <LoadingButton
+                  onClick={openSubscriptionDialog}
+                  variant="contained"
+                  size="large"
+                  fullWidth
+                  sx={{
+                    backgroundColor: (theme) => theme.palette.success.main,
+                    color: (theme) => theme.palette.common.black,
+                    '&:hover': {
+                      ...(!loadingSubscriptionUrl && {
+                        backgroundColor: (theme) => theme.palette.success.dark,
+                        color: (theme) => theme.palette.common.black,
+                      }),
+                    },
+                  }}
+                >
+                  Get memeSRC Pro
+                  {/* <Chip size='small' sx={{ ml: 1, backgroundColor: 'white', color: 'green' }} label="30% off" /> */}
+                </LoadingButton>
+                {/* <Typography
+                                    variant="caption"
+                                    display="block"
+                                    gutterBottom
+                                    align="center"
+                                    sx={{ pt: 1, marginTop: 1, opacity: 0.8 }}
+                                >
+                                    69 credits/mo for <del>$6.00</del> $4.20. Cancel any time.
+                                </Typography> */}
+              </>
+            )}
+          </Grid>
+        </Grid>
+
+      </Card>
+      <Card sx={{ p: 2 }}>
+        <Box>
+          <Typography variant="h4" gutterBottom>
+            Invoices
+          </Typography>
+          <div style={{ width: '100%', height: '100%' }}>
+            <DataGrid
+              rows={invoices}
+              columns={columns}
+              pageSize={5}
+              rowsPerPageOptions={[5]}
+              loading={loading}
+              autoHeight
+              disableSelectionOnClick
+              sx={{
+                '& .header': {
+                  backgroundColor: 'rgba(0, 0, 0, 0.1)',
+                  fontSize: '1.2rem',
+                  fontWeight: 'bold',
+                },
+                '& .cell': {
+                  fontSize: '1.1rem',
+                },
+              }}
+            />
+          </div>
+          {hasMore && !loading && (
+            <Button variant="outlined" onClick={handleLoadMore}>
+              Load More
+            </Button>
+          )}
+        </Box>
+      </Card>
+    </Container>
+  );
+};
+
+export default InvoiceListPage;

--- a/src/routes.js
+++ b/src/routes.js
@@ -56,6 +56,7 @@ const WebsiteSettings = lazy(() => import('./pages/WebsiteSettings'))
 const ProSupport = lazy(() => import('./pages/ProSupport'));
 const ProSupportAdmin = lazy(() => import('./pages/ProSupportAdmin'));
 const FAQPage = lazy(() => import('./pages/FAQPage'));
+const InvoiceListPage = lazy(() => import('./pages/InvoicesListPage'));
 
 const DonationRedirect = () => {
   window.location.href = 'https://buy.stripe.com/6oEeYJ2EJ4vH3Ha7ss';
@@ -76,6 +77,7 @@ export default function Router() {
         { path: 'pro', element: <SiteWideMaintenance><HomePage /></SiteWideMaintenance>, index: true },
         { path: 'search', element: <SiteWideMaintenance><Navigate to='/' /></SiteWideMaintenance> },
         { path: 'edit', element: <SiteWideMaintenance><EditorNewProjectPage /></SiteWideMaintenance> },
+        { path: 'manageSubscription', element: <SiteWideMaintenance><InvoiceListPage /></SiteWideMaintenance> },
         { path: 'editor/projects', element: <SiteWideMaintenance><EditorProjectsPage /></SiteWideMaintenance> },
         { path: 'editor/new', element: <SiteWideMaintenance><EditorNewProjectPage /></SiteWideMaintenance> },
         { path: 'editor/project/:editorProjectId', element: <SiteWideMaintenance><EditorPage /></SiteWideMaintenance> },


### PR DESCRIPTION
This PR adds a new page for subscription management. It shows what plan you're on (using the last paid invoice as reference IF you're still subscribed), and has a button to manage your subscription on stripe. This button works the same way as the manage subscription button in the popover worked.

Additionally, the page also gives you a list of your invoices with a button to download the PDF. It shows the status of each invoice, the invoice number, and the billing period for the invoice. This comes along with a backend function that will return the users invoices.

Finally, this updates all manage subscription buttons to direct the user to this new page.

![Screenshot 2024-04-22 at 9 40 23 PM](https://github.com/Vibe-House-LLC/memeSRC/assets/93208415/2129cb4e-0f87-4cac-a346-ce44b4a0f2e5)
