### PR TITLE
Add error handling to json parsing

### DIFF
--- a/amplify/backend/function/memesrcSearchV2/src/index.js
+++ b/amplify/backend/function/memesrcSearchV2/src/index.js
@@ -85,15 +85,20 @@ exports.handler = async (event) => {
                     data += chunk;
                 });
                 res.on('end', () => {
-                    resolve(JSON.parse(data));
+                    try {
+                        resolve(JSON.parse(data));
+                    } catch (error) {
+                        console.error('JSON Parse Error:', error);
+                        reject(error);
+                    }
                 });
             });
-
+        
             req.on('error', (error) => {
                 console.error('OpenSearch Error:', error);
                 reject(error);
             });
-
+        
             req.write(JSON.stringify(searchPayload));
             req.end();
         });


### PR DESCRIPTION
This is a hot fix for cases when opensearch is down. The JSON parsing was in a callback, which wasn't being caught with error handling.