### PR TITLE
Use local storage for index selection cache

### DIFF
--- a/src/pages/FavoritesPage.js
+++ b/src/pages/FavoritesPage.js
@@ -208,7 +208,7 @@ const FavoritesPage = () => {
 
   const clearSessionCache = async () => {
     const cacheKey = await getCacheKey();
-    sessionStorage.removeItem(cacheKey);
+    localStorage.removeItem(cacheKey);
   };
 
   const addFavorite = async (indexId) => {

--- a/src/utils/fetchShows.js
+++ b/src/utils/fetchShows.js
@@ -112,14 +112,14 @@ async function updateCacheAndReturnData(data, cacheKey) {
     data,
     updatedAt: Date.now(),
   };
-  sessionStorage.setItem(cacheKey, JSON.stringify(cacheData));
+  localStorage.setItem(cacheKey, JSON.stringify(cacheData));
 
   return data;
 }
 
 export default async function fetchShows() {
   const CACHE_KEY = await getCacheKey();
-  const cachedData = sessionStorage.getItem(CACHE_KEY);
+  const cachedData = localStorage.getItem(CACHE_KEY);
 
   async function refreshDataInBackground() {
     const freshData = await fetchShowsFromAPI();


### PR DESCRIPTION
This PR uses localStorage instead of sessionStorage to cache the index selection dropdown