### PR TITLE
Optimizing function storage to fix frame extractor

### DIFF
--- a/amplify/backend/function/frameExtractor/src/index.js
+++ b/amplify/backend/function/frameExtractor/src/index.js
@@ -90,6 +90,10 @@ exports.handler = async (event) => {
     const imageBuffer = fs.readFileSync(outputFile);
     const base64Image = imageBuffer.toString('base64');
 
+    // Clean up temporary files
+    fs.unlinkSync(videoFile);
+    fs.unlinkSync(outputFile);
+
     const lambdaResponse = {
       statusCode: 200,
       headers: {


### PR DESCRIPTION
This PR optimizes the use storage in the Frame Extractor lambda. It wasn't cleaning up temporary files and started failing under load from `no space left`.