### PR TITLE
Fix shows caching

### DIFF
--- a/src/contexts/useShows.js
+++ b/src/contexts/useShows.js
@@ -43,128 +43,133 @@ const CACHE_EXPIRATION_MINUTES = 1; // Define cache expiration minutes
 export const ShowContext = createContext();
 
 export const ShowProvider = ({ children }) => {
-  const [shows, setShows] = useState([]);
-  const { user } = useContext(UserContext)
+    const [shows, setShows] = useState([]);
+    const { user } = useContext(UserContext)
 
-  useEffect(() => {
-    fetchShows();
-  }, [user]);
+    useEffect(() => {
+        fetchShows();
+    }, [user]);
 
-  async function getCacheKey() {
-    try {
-      const currentUser = await Auth.currentAuthenticatedUser();
-      return `showsCache-${currentUser.username}-${APP_VERSION}`;
-    } catch {
-      return `showsCache-${APP_VERSION}`;
-    }
-  }
-
-  async function fetchShowsFromAPI() {
-    const aliases = await API.graphql({
-      query: listAliasesQuery,
-      variables: { filter: {}, limit: 50 },
-      authMode: 'API_KEY',
-    });
-
-    const loadedV2Shows = aliases?.data?.listAliases?.items.filter(obj => obj?.v2ContentMetadata) || [];
-
-    const finalShows = loadedV2Shows.map(v2Show => ({
-      ...v2Show.v2ContentMetadata,
-      id: v2Show.id,
-      cid: v2Show.v2ContentMetadata.id
-    }));
-
-    const sortedMetadata = finalShows.sort((a, b) => {
-      const titleA = a.title.toLowerCase().replace(/^the\s+/, '');
-      const titleB = b.title.toLowerCase().replace(/^the\s+/, '');
-      return titleA.localeCompare(titleB);
-    });
-
-    return sortedMetadata;
-  }
-
-  async function fetchFavorites() {
-    const currentUser = await Auth.currentAuthenticatedUser();
-
-    let nextToken = null;
-    let allFavorites = [];
-
-    do {
-      // Disable ESLint check for await-in-loop
-      // eslint-disable-next-line no-await-in-loop
-      const result = await API.graphql(graphqlOperation(listFavorites, {
-        limit: 10,
-        nextToken,
-      }));
-
-      allFavorites = allFavorites.concat(result.data.listFavorites.items);
-      nextToken = result.data.listFavorites.nextToken;
-
-    } while (nextToken);
-
-    return allFavorites;
-  }
-
-  async function updateCacheAndReturnData(data, cacheKey) {
-    try {
-      const currentUser = await Auth.currentAuthenticatedUser();
-      const favorites = await fetchFavorites();
-      const favoriteShowIds = new Set(favorites.map(favorite => favorite.cid));
-
-      data = data.map(show => ({
-        ...show,
-        isFavorite: favoriteShowIds.has(show.id)
-      }));
-    } catch (error) {
-      // If there's an error fetching favorites (likely due to not being authenticated), return data without favorites.
+    async function getCacheKey() {
+        try {
+            const currentUser = await Auth.currentAuthenticatedUser();
+            return `showsCache-${currentUser.username}-${APP_VERSION}`;
+        } catch {
+            return `showsCache-${APP_VERSION}`;
+        }
     }
 
-    const cacheData = {
-      data,
-      updatedAt: Date.now(),
-    };
-    localStorage.setItem(cacheKey, JSON.stringify(cacheData));
+    async function fetchShowsFromAPI() {
+        const aliases = await API.graphql({
+            query: listAliasesQuery,
+            variables: { filter: {}, limit: 50 },
+            authMode: 'API_KEY',
+        });
 
-    return data;
-  }
+        const loadedV2Shows = aliases?.data?.listAliases?.items.filter(obj => obj?.v2ContentMetadata) || [];
 
-  async function fetchShows() {
-    const CACHE_KEY = await getCacheKey();
-    const cachedData = localStorage.getItem(CACHE_KEY);
+        const finalShows = loadedV2Shows.map(v2Show => ({
+            ...v2Show.v2ContentMetadata,
+            id: v2Show.id,
+            cid: v2Show.v2ContentMetadata.id
+        }));
 
-    async function refreshDataAndUpdateCache() {
-      const freshData = await fetchShowsFromAPI();
-      const updatedData = await updateCacheAndReturnData(freshData, CACHE_KEY);
-      setShows(updatedData);
+        const sortedMetadata = finalShows.sort((a, b) => {
+            const titleA = a.title.toLowerCase().replace(/^the\s+/, '');
+            const titleB = b.title.toLowerCase().replace(/^the\s+/, '');
+            return titleA.localeCompare(titleB);
+        });
+
+        return sortedMetadata;
     }
 
-    if (cachedData) {
-      const { updatedAt } = JSON.parse(cachedData);
-      const cacheAge = (Date.now() - updatedAt) / 1000 / 60;
+    async function fetchFavorites() {
+        const currentUser = await Auth.currentAuthenticatedUser();
 
-      if (cacheAge <= CACHE_EXPIRATION_MINUTES) {
-        refreshDataAndUpdateCache();
-        return;
-      }
-      setShows(JSON.parse(cachedData).data);
-      refreshDataAndUpdateCache();
-      return;
+        let nextToken = null;
+        let allFavorites = [];
+
+        do {
+            // Disable ESLint check for await-in-loop
+            // eslint-disable-next-line no-await-in-loop
+            const result = await API.graphql(graphqlOperation(listFavorites, {
+                limit: 10,
+                nextToken,
+            }));
+
+            allFavorites = allFavorites.concat(result.data.listFavorites.items);
+            nextToken = result.data.listFavorites.nextToken;
+
+        } while (nextToken);
+
+        return allFavorites;
     }
 
-    refreshDataAndUpdateCache();
-  }
+    async function updateCacheAndReturnData(data, cacheKey) {
+        try {
+            const currentUser = await Auth.currentAuthenticatedUser();
+            const favorites = user ? await fetchFavorites() : [];
+            const favoriteShowIds = new Set(favorites.map(favorite => favorite.cid));
 
-  return (
-    <ShowContext.Provider value={{ shows }}>
-      {children}
-    </ShowContext.Provider>
-  );
+            data = data.map(show => ({
+                ...show,
+                isFavorite: favoriteShowIds.has(show.id)
+            }));
+        } catch (error) {
+            // If there's an error fetching favorites (likely due to not being authenticated), return data without favorites.
+        }
+
+        const cacheData = {
+            data,
+            updatedAt: Date.now(),
+        };
+        localStorage.setItem(cacheKey, JSON.stringify(cacheData));
+
+        return data;
+    }
+
+    async function fetchShows() {
+        const CACHE_KEY = await getCacheKey();
+        const cachedData = localStorage.getItem(CACHE_KEY);
+
+        async function refreshDataAndUpdateCache() {
+            const freshData = await fetchShowsFromAPI();
+            const updatedData = await updateCacheAndReturnData(freshData, CACHE_KEY);
+            setShows(updatedData);
+        }
+
+        let currentUser = null;
+        try {
+            currentUser = await Auth.currentAuthenticatedUser();
+        } catch (error) {
+            // If an error occurs, set currentUser to null
+            currentUser = null;
+        }
+
+        if (currentUser) {
+            // If user exists, fetch fresh data and update the cache
+            await refreshDataAndUpdateCache();
+        } else if (cachedData) {
+            // If user doesn't exist and there is cached data, return the cached data first
+            setShows(JSON.parse(cachedData).data);
+            refreshDataAndUpdateCache();
+        } else {
+            // If user doesn't exist and there is no cached data, fetch fresh data and update the cache
+            await refreshDataAndUpdateCache();
+        }
+    }
+
+    return (
+        <ShowContext.Provider value={{ shows }}>
+            {children}
+        </ShowContext.Provider>
+    );
 };
 
 export const useShows = () => {
-  const context = React.useContext(ShowContext);
-  if (context === undefined) {
-    throw new Error('useShows must be used within a ShowProvider');
-  }
-  return context;
+    const context = React.useContext(ShowContext);
+    if (context === undefined) {
+        throw new Error('useShows must be used within a ShowProvider');
+    }
+    return context;
 };

--- a/src/contexts/useShows.js
+++ b/src/contexts/useShows.js
@@ -1,0 +1,170 @@
+// ShowContext.js
+import React, { createContext, useState, useEffect, useContext } from 'react';
+import { API, graphqlOperation, Auth } from 'aws-amplify';
+import { listFavorites } from '../graphql/queries';
+import { UserContext } from '../UserContext';
+
+const listAliasesQuery = /* GraphQL */ `
+  query ListAliases(
+    $filter: ModelAliasFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listAliases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        createdAt
+        updatedAt
+        aliasV2ContentMetadataId
+        v2ContentMetadata {
+          colorMain
+          colorSecondary
+          createdAt
+          description
+          emoji
+          frameCount
+          title
+          updatedAt
+          status
+          id
+          version
+        }
+        __typename
+      }
+      nextToken
+      __typename
+    }
+  }
+`;
+
+const APP_VERSION = process.env.REACT_APP_VERSION || 'defaultVersion';
+const CACHE_EXPIRATION_MINUTES = 1; // Define cache expiration minutes
+
+export const ShowContext = createContext();
+
+export const ShowProvider = ({ children }) => {
+  const [shows, setShows] = useState([]);
+  const { user } = useContext(UserContext)
+
+  useEffect(() => {
+    fetchShows();
+  }, [user]);
+
+  async function getCacheKey() {
+    try {
+      const currentUser = await Auth.currentAuthenticatedUser();
+      return `showsCache-${currentUser.username}-${APP_VERSION}`;
+    } catch {
+      return `showsCache-${APP_VERSION}`;
+    }
+  }
+
+  async function fetchShowsFromAPI() {
+    const aliases = await API.graphql({
+      query: listAliasesQuery,
+      variables: { filter: {}, limit: 50 },
+      authMode: 'API_KEY',
+    });
+
+    const loadedV2Shows = aliases?.data?.listAliases?.items.filter(obj => obj?.v2ContentMetadata) || [];
+
+    const finalShows = loadedV2Shows.map(v2Show => ({
+      ...v2Show.v2ContentMetadata,
+      id: v2Show.id,
+      cid: v2Show.v2ContentMetadata.id
+    }));
+
+    const sortedMetadata = finalShows.sort((a, b) => {
+      const titleA = a.title.toLowerCase().replace(/^the\s+/, '');
+      const titleB = b.title.toLowerCase().replace(/^the\s+/, '');
+      return titleA.localeCompare(titleB);
+    });
+
+    return sortedMetadata;
+  }
+
+  async function fetchFavorites() {
+    const currentUser = await Auth.currentAuthenticatedUser();
+
+    let nextToken = null;
+    let allFavorites = [];
+
+    do {
+      // Disable ESLint check for await-in-loop
+      // eslint-disable-next-line no-await-in-loop
+      const result = await API.graphql(graphqlOperation(listFavorites, {
+        limit: 10,
+        nextToken,
+      }));
+
+      allFavorites = allFavorites.concat(result.data.listFavorites.items);
+      nextToken = result.data.listFavorites.nextToken;
+
+    } while (nextToken);
+
+    return allFavorites;
+  }
+
+  async function updateCacheAndReturnData(data, cacheKey) {
+    try {
+      const currentUser = await Auth.currentAuthenticatedUser();
+      const favorites = await fetchFavorites();
+      const favoriteShowIds = new Set(favorites.map(favorite => favorite.cid));
+
+      data = data.map(show => ({
+        ...show,
+        isFavorite: favoriteShowIds.has(show.id)
+      }));
+    } catch (error) {
+      // If there's an error fetching favorites (likely due to not being authenticated), return data without favorites.
+    }
+
+    const cacheData = {
+      data,
+      updatedAt: Date.now(),
+    };
+    localStorage.setItem(cacheKey, JSON.stringify(cacheData));
+
+    return data;
+  }
+
+  async function fetchShows() {
+    const CACHE_KEY = await getCacheKey();
+    const cachedData = localStorage.getItem(CACHE_KEY);
+
+    async function refreshDataAndUpdateCache() {
+      const freshData = await fetchShowsFromAPI();
+      const updatedData = await updateCacheAndReturnData(freshData, CACHE_KEY);
+      setShows(updatedData);
+    }
+
+    if (cachedData) {
+      const { updatedAt } = JSON.parse(cachedData);
+      const cacheAge = (Date.now() - updatedAt) / 1000 / 60;
+
+      if (cacheAge <= CACHE_EXPIRATION_MINUTES) {
+        refreshDataAndUpdateCache();
+        return;
+      }
+      setShows(JSON.parse(cachedData).data);
+      refreshDataAndUpdateCache();
+      return;
+    }
+
+    refreshDataAndUpdateCache();
+  }
+
+  return (
+    <ShowContext.Provider value={{ shows }}>
+      {children}
+    </ShowContext.Provider>
+  );
+};
+
+export const useShows = () => {
+  const context = React.useContext(ShowContext);
+  if (context === undefined) {
+    throw new Error('useShows must be used within a ShowProvider');
+  }
+  return context;
+};

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,5 +1,5 @@
 import { API } from 'aws-amplify';
-import React, { useState, useCallback, useEffect, useContext } from 'react';
+import React, { useState, useCallback, useEffect, useContext, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import FullScreenSearch from '../sections/search/FullScreenSearch';
@@ -73,21 +73,24 @@ export default function SearchPage({ metadata }) {
 
   }, [seriesTitle, searchTerm, navigate, savedCids]);
 
+  const memoizedFullScreenSearch = useMemo(() => (
+    <FullScreenSearch
+      searchFunction={handleSearch}
+      setSearchTerm={setSearchTerm}
+      setSeriesTitle={setSeriesTitle}
+      searchTerm={searchTerm}
+      seriesTitle={seriesTitle}
+      shows={shows}
+      metadata={metadata}
+    />
+  ), [handleSearch, setSearchTerm, setSeriesTitle, searchTerm, seriesTitle, shows, metadata]);
+
   return (
     <>
       <Helmet>
         <title>memeSRC</title>
       </Helmet>
-      <FullScreenSearch
-        searchFunction={handleSearch}
-        setSearchTerm={setSearchTerm}
-        setSeriesTitle={setSeriesTitle}
-        searchTerm={searchTerm}
-        seriesTitle={seriesTitle}
-        shows={shows}
-        // setShows={setShows}
-        metadata={metadata}
-      />
+      {memoizedFullScreenSearch}
     </>
   );
 }

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -32,6 +32,10 @@ export default function SearchPage({ metadata }) {
   const { shows } = useShows();
   const { savedCids, setSearchQuery: setV2SearchQuery } = useSearchDetailsV2()
 
+  useEffect(() => {
+    console.log('Loaded Default')
+  }, [defaultSeries]);
+
   const navigate = useNavigate();
 
   useEffect(() => {

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -6,6 +6,7 @@ import FullScreenSearch from '../sections/search/FullScreenSearch';
 import useSearchDetails from '../hooks/useSearchDetails';
 import useSearchDetailsV2 from '../hooks/useSearchDetailsV2';
 import { UserContext } from '../UserContext';
+import { useShows } from '../contexts/useShows';
 
 const prepSessionID = async () => {
   let sessionID;
@@ -28,7 +29,7 @@ export default function SearchPage({ metadata }) {
   const [searchTerm, setSearchTerm] = useState('');
   const defaultSeries = window.localStorage.getItem(`defaultsearch${user?.sub}`)
   const [seriesTitle, setSeriesTitle] = useState(defaultSeries || '_universal');
-  const [shows, setShows] = useState([]);
+  const { shows } = useShows();
   const { savedCids, setSearchQuery: setV2SearchQuery } = useSearchDetailsV2()
 
   const navigate = useNavigate();
@@ -80,7 +81,7 @@ export default function SearchPage({ metadata }) {
         searchTerm={searchTerm}
         seriesTitle={seriesTitle}
         shows={shows}
-        setShows={setShows}
+        // setShows={setShows}
         metadata={metadata}
       />
     </>

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,6 +5,7 @@ import EditorProjectsPage from './pages/EditorProjectsPage';
 import { V2SearchDetailsProvider } from './contexts/V2SearchDetailsProvider';
 import SiteWideMaintenance from './pages/SiteWideMaintenance';
 import { DialogProvider } from './contexts/SubscribeDialog';
+import { ShowProvider } from './contexts/useShows';
 
 
 // ----------------------------------------------------------------------
@@ -74,7 +75,7 @@ export default function Router() {
   const routes = useRoutes([
     {
       path: '/',
-      element: <GuestAuth><DialogProvider><MagicPopup><V2SearchDetailsProvider><DashboardLayout /></V2SearchDetailsProvider></MagicPopup></DialogProvider></GuestAuth>,
+      element: <GuestAuth><ShowProvider><DialogProvider><MagicPopup><V2SearchDetailsProvider><DashboardLayout /></V2SearchDetailsProvider></MagicPopup></DialogProvider></ShowProvider></GuestAuth>,
       children: [
         { element: <SiteWideMaintenance><HomePage /></SiteWideMaintenance>, index: true },
         { path: 'pro', element: <SiteWideMaintenance><HomePage /></SiteWideMaintenance>, index: true },

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -325,10 +325,10 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
   useEffect(() => {
     async function getData() {
       // Get shows
-      const fetchedShows = await fetchShows();
-      console.log(fetchedShows)
-      setShows(fetchedShows);
-      setAliasesWithMetadata(fetchedShows);
+      // const fetchedShows = await fetchShows();
+      // console.log(fetchedShows)
+      // setShows(fetchedShows);
+      // setAliasesWithMetadata(fetchedShows);
       setLoading(false);
       setAliasesLoading(false);
 

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { Alert, AlertTitle, Button, Fab, Grid, Typography, IconButton, Stack, useMediaQuery, Select, MenuItem, Chip, Container, ListSubheader, useTheme } from '@mui/material';
 import { Box } from '@mui/system';
 import { ArrowDownwardRounded, Favorite, MapsUgc, Shuffle } from '@mui/icons-material';
-import { API, graphqlOperation } from 'aws-amplify';
+import { API, Auth, graphqlOperation } from 'aws-amplify';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { LoadingButton } from '@mui/lab';
 import { useNavigate, useParams, Link, useLocation } from 'react-router-dom';
@@ -549,13 +549,19 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
   }
 
   useEffect(() => {
-    const defaultSeries = window.localStorage.getItem(`defaultsearch${user?.sub}`)
-    console.log(user?.sub)
-    setCid(seriesId || metadata?.id || defaultSeries || '_universal')
+
+    Auth.currentAuthenticatedUser().then(authUser => {
+      console.log(authUser)
+      const defaultSeries = window.localStorage.getItem(`defaultsearch${authUser?.attributes?.sub}`)
+      console.log(user?.sub)
+      setCid(seriesId || metadata?.id || defaultSeries || '_universal')
+    }).catch(() => {
+      setCid(seriesId || metadata?.id || '_universal')
+    });
+
 
     return () => {
       if (pathname === '/') {
-        setCid(defaultSeries || null)
         setShowObj(null)
         setSearchQuery(null)
         setCidSearchQuery('')

--- a/src/sections/search/ipfs-search-bar.js
+++ b/src/sections/search/ipfs-search-bar.js
@@ -16,6 +16,7 @@ import AddCidPopup from "../../components/ipfs/add-cid-popup";
 import { UserContext } from "../../UserContext";
 import fetchShows from "../../utils/fetchShows";
 import useLoadRandomFrame from "../../utils/loadRandomFrame";
+import { useShows } from "../../contexts/useShows";
 
 // Define constants for colors and fonts
 const PRIMARY_COLOR = '#4285F4';
@@ -89,7 +90,8 @@ export default function IpfsSearchBar(props) {
   const { show, setShow, searchQuery, setSearchQuery, cid = '', setCid, localCids, setLocalCids, showObj, setShowObj, selectedFrameIndex, setSelectedFrameIndex, savedCids, loadingSavedCids } = useSearchDetailsV2();
   const { setShow: setV1Show, setSeriesTitle: setV1SeriesTitle } = useSearchDetails();
   const params = useParams();
-  const [shows, setShows] = useState([]);
+  // const [shows, setShows] = useState([]);
+  const { shows } = useShows();
   const [loading, setLoading] = useState(true);
   const { children } = props
   const { pathname } = useLocation();
@@ -169,16 +171,16 @@ export default function IpfsSearchBar(props) {
 
   /* -------------------------------------------------------------------------- */
 
-  useEffect(() => {
-    async function getData() {
-      // Get shows
-      const shows = await fetchShows();
-      console.log(shows)
-      setShows(shows);
-      setLoading(false);
-    }
-    getData();
-  }, []);
+  // useEffect(() => {
+  //   async function getData() {
+  //     // Get shows
+  //     const shows = await fetchShows();
+  //     console.log(shows)
+  //     setShows(shows);
+  //     setLoading(false);
+  //   }
+  //   getData();
+  // }, []);
 
   const getSessionID = async () => {
     let sessionID;


### PR DESCRIPTION
This PR fixes caching of shows by adding a context that holds the show state. All search pages now look at this context for the show list. It uses a useEffect which will be fired on load and anytime the `user` context changes. 

Most of the logic is directly pulled from the original fetchShows function with some minor tweaks.