### PR TITLE
Add shows handling to guest auth wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/UserContext.js
+++ b/src/UserContext.js
@@ -3,5 +3,9 @@ import { createContext } from 'react'
 export const UserContext = createContext({
     user: false,
     setUser: () => {},
-    login: () => {}
+    shows: [],
+    setShows: () => {},
+    defaultShow: false,
+    handleUpdateDefaultShow: () => {},
+    setDefaultShow: () => {}
 });

--- a/src/layouts/dashboard/header/AccountPopover.js
+++ b/src/layouts/dashboard/header/AccountPopover.js
@@ -8,6 +8,7 @@ import { API, Auth } from 'aws-amplify';
 import { UserContext } from '../../../UserContext';
 import account from '../../../_mock/account';
 import { useSubscribeDialog } from '../../../contexts/useSubscribeDialog';
+import { getShowsWithFavorites } from '../../../utils/fetchShowsRevised';
 
 // ----------------------------------------------------------------------
 
@@ -64,11 +65,18 @@ export default function AccountPopover() {
 
   const logout = () => {
     Auth.signOut().then(() => {
-      window.localStorage.removeItem('memeSRCUserInfo')
-      userDetails?.setUser(false);
-      navigate('/login')
+      userDetails?.setUser(null);
+      window.localStorage.removeItem('memeSRCUserDetails')
+      console.log('USER GONE')
+      userDetails?.setDefaultShow('_universal')
+      getShowsWithFavorites().then(loadedShows => {
+        window.localStorage.setItem('memeSRCShows', JSON.stringify(loadedShows))
+        userDetails?.setShows(loadedShows)
+      })
     }).catch((err) => {
       alert(err)
+    }).finally(() => {
+      navigate('/login')
     })
   }
 

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -25,11 +25,14 @@ const prepSessionID = async () => {
 
 export default function SearchPage({ metadata }) {
   const { setSearchQuery } = useSearchDetails();
-  const { user, defaultShow } = useContext(UserContext)
+  const { user, defaultShow, shows } = useContext(UserContext)
   const [searchTerm, setSearchTerm] = useState('');
-  const [seriesTitle, setSeriesTitle] = useState(defaultShow);
-  const { shows } = useShows();
+  const [seriesTitle, setSeriesTitle] = useState(shows.some(show => show.isFavorite) ? defaultShow : '_universal');
   const { savedCids, setSearchQuery: setV2SearchQuery } = useSearchDetailsV2()
+
+  useEffect(() => {
+    console.log(shows.some(show => show.isFavorite))
+  }, []);
 
   const navigate = useNavigate();
 

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -25,16 +25,11 @@ const prepSessionID = async () => {
 
 export default function SearchPage({ metadata }) {
   const { setSearchQuery } = useSearchDetails();
-  const { user } = useContext(UserContext)
+  const { user, defaultShow } = useContext(UserContext)
   const [searchTerm, setSearchTerm] = useState('');
-  const defaultSeries = window.localStorage.getItem(`defaultsearch${user?.sub}`)
-  const [seriesTitle, setSeriesTitle] = useState(defaultSeries || '_universal');
+  const [seriesTitle, setSeriesTitle] = useState(defaultShow);
   const { shows } = useShows();
   const { savedCids, setSearchQuery: setV2SearchQuery } = useSearchDetailsV2()
-
-  useEffect(() => {
-    console.log('Loaded Default')
-  }, [defaultSeries]);
 
   const navigate = useNavigate();
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -136,7 +136,7 @@ export default function Router() {
     },
     {
       path: '/login',
-      element: <CheckAuth><AuthPage><LoginForm /></AuthPage></CheckAuth>,
+      element: <GuestAuth><AuthPage><LoginForm /></AuthPage></GuestAuth>,
     },
     {
       path: '/signup',

--- a/src/sections/auth/login/GuestAuth.js
+++ b/src/sections/auth/login/GuestAuth.js
@@ -55,7 +55,8 @@ export default function GuestAuth(props) {
       console.log(localStorageUser)
 
       if (localStorageUser) {
-        setDefaultShow(localStorageDefaultShow)
+        console.log(localStorageShows.some(show => show.isFavorite))
+        setDefaultShow(localStorageShows.some(show => show.isFavorite) ? localStorageDefaultShow : '_universal')
         setUser(localStorageUser)
       } else {
         setUser(false)
@@ -73,6 +74,9 @@ export default function GuestAuth(props) {
       Auth.currentAuthenticatedUser().then((x) => {
         API.get('publicapi', '/user/get').then(userDetails => {
           getShowsWithFavorites().then(loadedShows => {
+            if (!shows.some(show => show.isFavorite)) {
+              setDefaultShow('_universal')
+            }
             setUser({ ...x, ...x.signInUserSession.accessToken.payload, userDetails: userDetails?.data?.getUserDetails })  // if an authenticated user is found, set it into the context
             // console.log(x)
             window.localStorage.setItem('memeSRCUserDetails', JSON.stringify({ ...x.signInUserSession.accessToken.payload, userDetails: userDetails?.data?.getUserDetails }))
@@ -88,6 +92,9 @@ export default function GuestAuth(props) {
         }).catch(err => console.log(err))
       }).catch(() => {
         getShowsWithFavorites().then(loadedShows => {
+          if (!shows.some(show => show.isFavorite)) {
+            setDefaultShow('_universal')
+          }
           setUser(false)  // indicate the context is ready but user is not auth'd
           window.localStorage.removeItem('memeSRCUserInfo')
           window.localStorage.setItem('memeSRCShows', JSON.stringify(loadedShows))

--- a/src/sections/auth/login/LoginForm.js
+++ b/src/sections/auth/login/LoginForm.js
@@ -8,6 +8,7 @@ import { API, Auth } from 'aws-amplify';
 import Iconify from '../../../components/iconify';
 import { UserContext } from '../../../UserContext';
 import { SnackbarContext } from '../../../SnackbarContext';
+import { getShowsWithFavorites } from '../../../utils/fetchShowsRevised';
 
 
 // ----------------------------------------------------------------------
@@ -44,7 +45,7 @@ export default function LoginForm() {
 
   const loginForm = useRef();
 
-  const { setUser } = useContext(UserContext)
+  const { setUser, handleUpdateDefaultShow, setShows } = useContext(UserContext)
 
   // Use the useLocation hook to get the location object
   const location = useLocation();
@@ -67,8 +68,13 @@ export default function LoginForm() {
     if (username && password) {
       Auth.signIn(username, password).then((x) => {
         API.post('publicapi', '/user/update/status').then(response => {
-          setUser(x)
-          navigate(dest ? decodeURIComponent(dest) : '/', { replace: true })
+          getShowsWithFavorites().then(loadedShows => {
+            setShows(loadedShows)
+            window.localStorage.setItem('memeSRCShows', JSON.stringify(loadedShows))
+            setUser(x)
+            handleUpdateDefaultShow(window.localStorage.getItem('memeSRCDefaultShow'))
+            navigate(dest ? decodeURIComponent(dest) : '/', { replace: true })
+          })
         })
       }).catch((error) => {
         console.log(error.name)

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -235,8 +235,6 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
   const isMd = useMediaQuery((theme) => theme.breakpoints.up('sm'));
   const [addNewCidOpen, setAddNewCidOpen] = useState(false);
   const { user, setUser, shows, setShows, defaultShow, handleUpdateDefaultShow } = useContext(UserContext);
-  console.log('SHOWS: ', shows || 'NO SHOWS')
-  console.log('DEFAULT SHOW: ', defaultShow || 'NO DEFAULT SHOW')
   const { pathname } = useLocation();
   const { loadRandomFrame, loadingRandom, error } = useLoadRandomFrame();
 
@@ -347,7 +345,8 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
     console.log(defaultShow)
     if (shows.length > 0) {
       // Determine the series to use based on the URL or default to '_universal'
-      const currentSeriesId = seriesId || defaultShow;
+      const currentSeriesId = seriesId || (shows.some(show => show.isFavorite) ? defaultShow : '_universal');
+      console.log(seriesId || shows.some(show => show.isFavorite) ? defaultShow : '_universal')
       setShow(currentSeriesId)
 
       if (currentSeriesId !== seriesTitle) {
@@ -553,7 +552,8 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
 
   useEffect(() => {
 
-    setCid(seriesId || metadata?.id || defaultShow)
+    setCid(seriesId || metadata?.id || (shows.some(show => show.isFavorite) ? defaultShow : '_universal'))
+    console.log(seriesId || metadata?.id || shows.some(show => show.isFavorite) ? defaultShow : '_universal')
 
 
     return () => {
@@ -644,7 +644,7 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
             <Grid container justifyContent="center">
               <Grid item sm={3.5} xs={12} paddingX={0.25} paddingBottom={{ xs: 1, sm: 0 }}>
                 <Select
-                  value={cid || seriesTitle || defaultShow}
+                  value={cid || seriesTitle || (shows.some(show => show.isFavorite) ? defaultShow : '_universal')}
                   onChange={(e) => {
                     const selectedId = e.target.value;
 

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -225,7 +225,7 @@ const defaultBackground = `linear-gradient(45deg,
   #00ab84 0, #00ab84 87.5% /* 7*12.5% */,
   #00a3e0 0)`;
 
-export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitle, setSeriesTitle, searchFunction, shows, setShows, metadata }) {
+export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitle, setSeriesTitle, searchFunction, metadata }) {
   const { localCids, setLocalCids, savedCids, cid, setCid, searchQuery: cidSearchQuery, setSearchQuery: setCidSearchQuery, setShowObj, loadingSavedCids } = useSearchDetailsV2()
   const [sections, setSections] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -234,7 +234,9 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
   const { show, setShow, searchQuery, setSearchQuery } = useSearchDetails();
   const isMd = useMediaQuery((theme) => theme.breakpoints.up('sm'));
   const [addNewCidOpen, setAddNewCidOpen] = useState(false);
-  const { user, setUser } = useContext(UserContext);
+  const { user, setUser, shows, setShows, defaultShow, handleUpdateDefaultShow } = useContext(UserContext);
+  console.log('SHOWS: ', shows || 'NO SHOWS')
+  console.log('DEFAULT SHOW: ', defaultShow || 'NO DEFAULT SHOW')
   const { pathname } = useLocation();
   const { loadRandomFrame, loadingRandom, error } = useLoadRandomFrame();
 
@@ -342,34 +344,21 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
   // This useEffect ensures the theme is applied based on the seriesId once the data is loaded
   useEffect(() => {
     // Check if shows have been loaded
+    console.log(defaultShow)
     if (shows.length > 0) {
+      // Determine the series to use based on the URL or default to '_universal'
+      const currentSeriesId = seriesId || defaultShow;
+      setShow(currentSeriesId)
 
-      Auth.currentAuthenticatedUser().then(authUser => {
-        const currentSeriesId = seriesId || window.localStorage.getItem(`defaultsearch${authUser?.attributes?.sub}`) || '_universal'
-        setShow(currentSeriesId)
-        if (currentSeriesId !== seriesTitle) {
-          setSeriesTitle(currentSeriesId); // Update the series title based on the URL parameter
-          handleChangeSeries(currentSeriesId); // Update the theme
+      if (currentSeriesId !== seriesTitle) {
+        setSeriesTitle(currentSeriesId); // Update the series title based on the URL parameter
+        handleChangeSeries(currentSeriesId); // Update the theme
 
-          // Navigation logic
-          navigate((currentSeriesId === '_universal') ? '/' : `/${currentSeriesId}`);
-        }
-      }).catch(() => {
-        // Determine the series to use based on the URL or default to '_universal'
-        const currentSeriesId = seriesId || '_universal';
-        setShow(currentSeriesId)
-
-        if (currentSeriesId !== seriesTitle) {
-          setSeriesTitle(currentSeriesId); // Update the series title based on the URL parameter
-          handleChangeSeries(currentSeriesId); // Update the theme
-
-          // Navigation logic
-          navigate((currentSeriesId === '_universal') ? '/' : `/${currentSeriesId}`);
-        }
-      });
-
+        // Navigation logic
+        navigate((currentSeriesId === '_universal') ? '/' : `/${currentSeriesId}`);
+      }
     }
-  }, [seriesId, seriesTitle, shows, handleChangeSeries, navigate]);
+  }, [seriesId, seriesTitle, shows, handleChangeSeries, navigate, defaultShow]);
 
   useEffect(() => {
     if (pathname === '/_favorites') {
@@ -564,25 +553,23 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
 
   useEffect(() => {
 
-    Auth.currentAuthenticatedUser().then(authUser => {
-      console.log(authUser)
-      const defaultSeries = window.localStorage.getItem(`defaultsearch${authUser?.attributes?.sub}`)
-      console.log(user?.sub)
-      setCid(seriesId || metadata?.id || defaultSeries || '_universal')
-    }).catch(() => {
-      setCid(seriesId || metadata?.id || '_universal')
-    });
+    setCid(seriesId || metadata?.id || defaultShow)
 
 
     return () => {
       if (pathname === '/') {
+        // setCid(defaultShow || '_universal')
         setShowObj(null)
         setSearchQuery(null)
         setCidSearchQuery('')
         console.log('Unset CID')
       }
     }
-  }, [pathname]);
+  }, [pathname, defaultShow]);
+
+  useEffect(() => {
+    console.log('CHANGING DEFAULT: ', defaultShow)
+  }, [defaultShow]);
 
   return (
     <>
@@ -657,7 +644,7 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
             <Grid container justifyContent="center">
               <Grid item sm={3.5} xs={12} paddingX={0.25} paddingBottom={{ xs: 1, sm: 0 }}>
                 <Select
-                  value={cid || seriesTitle}
+                  value={cid || seriesTitle || defaultShow}
                   onChange={(e) => {
                     const selectedId = e.target.value;
 
@@ -671,7 +658,7 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
                       setSeriesTitle(newSeriesTitle);
                       handleChangeSeries(newSeriesTitle);
                       if (newSeriesTitle === '_universal' || newSeriesTitle === '_favorites') {
-                        window.localStorage.setItem(`defaultsearch${user?.sub}`, newSeriesTitle)
+                        handleUpdateDefaultShow(newSeriesTitle)
                       }
                       navigate((newSeriesTitle === '_universal') ? '/' : `/${newSeriesTitle}`);
                     }
@@ -695,6 +682,9 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
                     },
                   }}
                 >
+                  {console.log(shows || 'WAITING ON SHOWS')}
+                  {console.log(cid || seriesTitle || defaultShow)}
+                  {console.log(shows.some(show => show.isFavorite))}
                   <MenuItem value="_universal">🌈 All Shows & Movies</MenuItem>
 
                   {shows.some(show => show.isFavorite) ? (

--- a/src/sections/search/ipfs-search-bar.js
+++ b/src/sections/search/ipfs-search-bar.js
@@ -87,7 +87,6 @@ const StyledHeader = styled('header')(() => ({
 IpfsSearchBar.propTypes = searchPropTypes;
 
 export default function IpfsSearchBar(props) {
-  const { show, setShow, searchQuery, setSearchQuery, cid = '', setCid, localCids, setLocalCids, showObj, setShowObj, selectedFrameIndex, setSelectedFrameIndex, savedCids, loadingSavedCids } = useSearchDetailsV2();
   const { setShow: setV1Show, setSeriesTitle: setV1SeriesTitle } = useSearchDetails();
   const params = useParams();
   // const [shows, setShows] = useState([]);
@@ -95,6 +94,7 @@ export default function IpfsSearchBar(props) {
   const { children } = props
   const { pathname } = useLocation();
   const { user, shows, defaultShow, handleUpdateDefaultShow } = useContext(UserContext);
+  const { show, setShow, searchQuery, setSearchQuery, cid = defaultShow, setCid, localCids, setLocalCids, showObj, setShowObj, selectedFrameIndex, setSelectedFrameIndex, savedCids, loadingSavedCids } = useSearchDetailsV2();
   const { loadRandomFrame, loadingRandom, error } = useLoadRandomFrame();
   const [searchParams, setSearchParams] = useSearchParams();
   const searchTerm = searchParams.get('searchTerm');
@@ -201,7 +201,7 @@ export default function IpfsSearchBar(props) {
   const searchFunction = (searchEvent) => {
     searchEvent?.preventDefault();
     console.log(search)
-    navigate(`/search/${cid}/?searchTerm=${encodeURIComponent(search)}`)
+    navigate(`/search/${params?.seriesId || defaultShow}/?searchTerm=${encodeURIComponent(search)}`)
     return false
   }
 
@@ -279,17 +279,17 @@ export default function IpfsSearchBar(props) {
                   🌈 All Shows & Movies
                 </MenuItem>
 
-                {user?.userDetails?.subscriptionStatus === 'active' || shows.some(show => show.isFavorite) ? (
+                {shows.some(show => show.isFavorite) ? (
                   <MenuItem value="_favorites">
                     ⭐ All Favorites
                   </MenuItem>
                 ) : null}
 
-                {user?.userDetails?.subscriptionStatus === 'active' || shows.some(show => show.isFavorite) ? (
+                {shows.some(show => show.isFavorite) ? (
                   <ListSubheader key="favorites-subheader">Favorites</ListSubheader>
                 ) : null}
 
-                {(user?.userDetails?.subscriptionStatus === 'active' || shows.some(show => show.isFavorite)) && (
+                {(shows.some(show => show.isFavorite)) && (
                   shows.filter(show => show.isFavorite).map(show => (
                     <MenuItem key={show.id} value={show.id}>
                       ⭐ {show.emoji} {show.title}

--- a/src/sections/search/ipfs-search-bar.js
+++ b/src/sections/search/ipfs-search-bar.js
@@ -94,7 +94,7 @@ export default function IpfsSearchBar(props) {
   const { children } = props
   const { pathname } = useLocation();
   const { user, shows, defaultShow, handleUpdateDefaultShow } = useContext(UserContext);
-  const { show, setShow, searchQuery, setSearchQuery, cid = defaultShow, setCid, localCids, setLocalCids, showObj, setShowObj, selectedFrameIndex, setSelectedFrameIndex, savedCids, loadingSavedCids } = useSearchDetailsV2();
+  const { show, setShow, searchQuery, setSearchQuery, cid = shows.some(show => show.isFavorite) ? defaultShow : '_universal', setCid, localCids, setLocalCids, showObj, setShowObj, selectedFrameIndex, setSelectedFrameIndex, savedCids, loadingSavedCids } = useSearchDetailsV2();
   const { loadRandomFrame, loadingRandom, error } = useLoadRandomFrame();
   const [searchParams, setSearchParams] = useSearchParams();
   const searchTerm = searchParams.get('searchTerm');
@@ -109,7 +109,7 @@ export default function IpfsSearchBar(props) {
 
   useEffect(() => {
     if (!cid) {
-      setCid(params?.seriesId || defaultShow)
+      setCid(params?.seriesId || (shows.some(show => show.isFavorite) ? defaultShow : '_universal'))
     }
   }, [cid]);
 
@@ -201,7 +201,7 @@ export default function IpfsSearchBar(props) {
   const searchFunction = (searchEvent) => {
     searchEvent?.preventDefault();
     console.log(search)
-    navigate(`/search/${params?.seriesId || defaultShow}/?searchTerm=${encodeURIComponent(search)}`)
+    navigate(`/search/${params?.seriesId || (shows.some(show => show.isFavorite) ? defaultShow : '_universal')}/?searchTerm=${encodeURIComponent(search)}`)
     return false
   }
 

--- a/src/sections/search/ipfs-search-bar.js
+++ b/src/sections/search/ipfs-search-bar.js
@@ -91,11 +91,10 @@ export default function IpfsSearchBar(props) {
   const { setShow: setV1Show, setSeriesTitle: setV1SeriesTitle } = useSearchDetails();
   const params = useParams();
   // const [shows, setShows] = useState([]);
-  const { shows } = useShows();
   const [loading, setLoading] = useState(true);
   const { children } = props
   const { pathname } = useLocation();
-  const { user } = useContext(UserContext);
+  const { user, shows, defaultShow, handleUpdateDefaultShow } = useContext(UserContext);
   const { loadRandomFrame, loadingRandom, error } = useLoadRandomFrame();
   const [searchParams, setSearchParams] = useSearchParams();
   const searchTerm = searchParams.get('searchTerm');
@@ -110,7 +109,7 @@ export default function IpfsSearchBar(props) {
 
   useEffect(() => {
     if (!cid) {
-      setCid(params?.seriesId || window.localStorage.getItem(`defaultsearch${user?.sub}`) || '_universal')
+      setCid(params?.seriesId || defaultShow)
     }
   }, [cid]);
 

--- a/src/utils/fetchShowsRevised.js
+++ b/src/utils/fetchShowsRevised.js
@@ -1,0 +1,101 @@
+import { API, graphqlOperation, Auth } from 'aws-amplify';
+import { listFavorites } from '../graphql/queries';
+
+const listAliasesQuery = /* GraphQL */ `
+  query ListAliases(
+    $filter: ModelAliasFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listAliases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        createdAt
+        updatedAt
+        aliasV2ContentMetadataId
+        v2ContentMetadata {
+          colorMain
+          colorSecondary
+          createdAt
+          description
+          emoji
+          frameCount
+          title
+          updatedAt
+          status
+          id
+          version
+        }
+        __typename
+      }
+      nextToken
+      __typename
+    }
+  }
+`;
+
+async function fetchShows() {
+    const aliases = await API.graphql({
+        query: listAliasesQuery,
+        variables: { filter: {}, limit: 50 },
+        authMode: 'API_KEY',
+    });
+
+    const loadedV2Shows = aliases?.data?.listAliases?.items.filter(obj => obj?.v2ContentMetadata) || [];
+
+    const finalShows = loadedV2Shows.map(v2Show => ({
+        ...v2Show.v2ContentMetadata,
+        id: v2Show.id,
+        cid: v2Show.v2ContentMetadata.id
+    }));
+
+    const sortedMetadata = finalShows.sort((a, b) => {
+        const titleA = a.title.toLowerCase().replace(/^the\s+/, '');
+        const titleB = b.title.toLowerCase().replace(/^the\s+/, '');
+        return titleA.localeCompare(titleB);
+    });
+
+    return sortedMetadata;
+}
+
+async function fetchFavorites() {
+    let nextToken = null;
+    let allFavorites = [];
+
+    do {
+        // Disable ESLint check for await-in-loop
+        // eslint-disable-next-line no-await-in-loop
+        const result = await API.graphql(graphqlOperation(listFavorites, {
+            limit: 10,
+            nextToken,
+        }));
+
+        allFavorites = allFavorites.concat(result.data.listFavorites.items);
+        nextToken = result.data.listFavorites.nextToken;
+
+    } while (nextToken);
+
+    return allFavorites;
+}
+
+async function getShowsWithFavorites() {
+    const shows = await fetchShows();
+    
+    try {
+        await Auth.currentAuthenticatedUser();
+        const favorites = await fetchFavorites();
+        const favoriteShowIds = new Set(favorites.map(favorite => favorite.cid));
+
+        const showsWithFavorites = shows.map(show => ({
+            ...show,
+            isFavorite: favoriteShowIds.has(show.id)
+        }));
+
+        return showsWithFavorites;
+    } catch (error) {
+        // If there's an error fetching favorites (likely due to not being authenticated), return shows without favorites.
+        return shows;
+    }
+}
+
+export { getShowsWithFavorites };


### PR DESCRIPTION
This PR does a few things:

- Shows are now handled inside the guest auth wrapper
- The default show is handled by the guest auth wrapper
- There is a new fetchShowsRevised function that is used to return shows
- Shows and the default show are both cached under separate keys in local storage, but everything is handled exactly as the user details.