### PR TITLE
Improve cache hit rate by rounding frame selections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.1.11",
+      "version": "2.1.12",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -2001,7 +2001,7 @@ const EditorPage = ({ shows }) => {
                   <Button
                     variant="contained"
                     fullWidth
-                    href={`/episode/${cid}/${season}/${episode}/${frame}`}
+                    href={`/episode/${cid}/${season}/${episode}/${Math.round(frame / 10) * 10}${searchQuery ? `?searchTerm=${searchQuery}` : ''}`}
                   >
                     View Episode
                   </Button>

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -533,23 +533,6 @@ useEffect(() => {
     setSubtitlesExpanded(!subtitlesExpanded);
   };
 
-  const frameToTimecode = (frameNumber, fps) => {
-    const totalSeconds = Math.floor(frameNumber / fps);
-
-    const hours = Math.floor(totalSeconds / 3600);
-    const minutes = Math.floor((totalSeconds - (hours * 3600)) / 60);
-    const seconds = totalSeconds - (hours * 3600) - (minutes * 60);
-    const frames = frameNumber % fps;
-
-    // Format the output with leading zeroes where necessary
-    const hoursStr = String(hours).padStart(2, '0');
-    const minutesStr = String(minutes).padStart(2, '0');
-    const secondsStr = String(seconds).padStart(2, '0');
-    const framesStr = String(frames).padStart(2, '0');
-
-    return `${hoursStr}:${minutesStr}:${secondsStr}`;
-  };
-
   const { showObj, setShowObj, selectedFrameIndex, setSelectedFrameIndex } = useSearchDetailsV2();
   const [loadingCsv, setLoadingCsv] = useState();
   const [isBold, setIsBold] = useState(true);
@@ -850,7 +833,12 @@ useEffect(() => {
               size='small'
               icon={<OpenInNew />}
               label={`Season ${season} / Episode ${episode}`}
-              onClick={() => navigate(`/episode/${cid}/${season}/${episode}/1`)}
+              onClick={() => {
+                const frameRate = 10;
+                const totalSeconds = Math.round(frame / frameRate);
+                const nearestSecondFrame = totalSeconds * frameRate;
+                navigate(`/episode/${cid}/${season}/${episode}/${nearestSecondFrame}`);
+              }}
               sx={{
                 marginBottom: '15px',
                 "& .MuiChip-label": {
@@ -861,9 +849,13 @@ useEffect(() => {
             <Chip
               size='small'
               icon={<BrowseGallery />}
-              // TODO: I'm assuming there's probably some easy math to put the time code here
               label={`${frameToTimeCode(frame)}`}
-              onClick={() => navigate(`/episode/${cid}/${season}/${episode}/${frame}`)}
+              onClick={() => {
+                const frameRate = 10;
+                const totalSeconds = Math.round(frame / frameRate);
+                const nearestSecondFrame = totalSeconds * frameRate;
+                navigate(`/episode/${cid}/${season}/${episode}/${nearestSecondFrame}`);
+              }}
               sx={{
                 marginBottom: '15px',
                 marginLeft: '5px',
@@ -1470,7 +1462,7 @@ useEffect(() => {
               <Button
                 variant="contained"
                 fullWidth
-                href={`/episode/${cid}/${season}/${episode}/${frame}${searchQuery ? `?searchTerm=${searchQuery}` : ''}`}
+                href={`/episode/${cid}/${season}/${episode}/${Math.round(frame / 10) * 10}${searchQuery ? `?searchTerm=${searchQuery}` : ''}`}
               >
                 View Episode
               </Button>

--- a/src/pages/V2SearchPage.js
+++ b/src/pages/V2SearchPage.js
@@ -343,8 +343,8 @@ export default function SearchPage() {
   const loadVideoUrl = async (result, metadataCid) => {
     const resultCid = result.cid || metadataCid;
     const thumbnailUrl = animationsEnabled
-      ? `https://v2-${process.env.REACT_APP_USER_BRANCH}.memesrc.com/thumbnail/${resultCid}/${result.season}/${result.episode}/${result.subtitle_index}`
-      : `https://v2-${process.env.REACT_APP_USER_BRANCH}.memesrc.com/frame/${resultCid}/${result.season}/${result.episode}/${Math.round((parseInt(result.start_frame, 10) + parseInt(result.end_frame, 10)) / 2)}`;
+      ? `unsupported`
+      : `https://v2-${process.env.REACT_APP_USER_BRANCH}.memesrc.com/frame/${resultCid}/${result.season}/${result.episode}/${Math.round(((parseInt(result.start_frame, 10) + parseInt(result.end_frame, 10)) / 2) / 10) * 10}`;
     const resultId = `${result.season}-${result.episode}-${result.subtitle_index}`;
     setVideoUrls((prevVideoUrls) => ({ ...prevVideoUrls, [resultId]: thumbnailUrl }));
   };
@@ -659,9 +659,7 @@ export default function SearchPage() {
                       </StyledCard>
                     ) : (
                       <Link
-                        to={`/frame/${result.cid}/${result.season}/${result.episode}/${Math.round(
-                          (parseInt(result.start_frame, 10) + parseInt(result.end_frame, 10)) / 2
-                        )}${searchQuery ? `?searchTerm=${searchQuery}` : ''}`}
+                        to={`/frame/${result.cid}/${result.season}/${result.episode}/${Math.round(((parseInt(result.start_frame, 10) + parseInt(result.end_frame, 10)) / 2) / 10) * 10}${searchQuery ? `?searchTerm=${searchQuery}` : ''}`}
                         style={{ textDecoration: 'none' }}
                       >
                         <StyledCard>


### PR DESCRIPTION
# Description

This PR rounds frame numbers to the nearest equivalent whole-second timecode in:

- **Search Results** (images and frame page links, which intrinsically rounds nearby frames)
- **View Episode Links** (the bottom buttons, and frame page timecode & episode number buttons)

This should normalize all 'starting points' and improve cache hit rates by almost 10x (the current 'fps' value). 

# Background

Previously, searches results would provide the 'middle' frame of the matching subtitle range. This works fine, but since the nearby frames and episode browsers simple do whole-second steps to find other frames, it decreases likelihood of cache hits by a factor of 10 (the current 'fps' value).