### PR TITLE
Improve discoverability of collage tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.1.19",
+      "version": "2.1.20",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/nav-section/NavSection.js
+++ b/src/components/nav-section/NavSection.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Link, NavLink as RouterLink } from 'react-router-dom';
 // @mui
-import { Box, List, ListItemText, Typography } from '@mui/material';
+import { Box, List, ListItemText, Typography, Chip } from '@mui/material';
 //
 import { Fragment, useContext, useEffect } from 'react';
 import { StyledNavItem, StyledNavItemIcon } from './styles';
@@ -14,48 +14,42 @@ NavSection.propTypes = {
 };
 
 export default function NavSection({ data = [], ...other }) {
-  const { user } = useContext(UserContext)
-  // useEffect(() => {
-  //   console.log(user)
-  // }, [user])
+  const { user } = useContext(UserContext);
+
   return (
     <>
-      {
-        !user?.['cognito:groups']?.includes('admins') && <Box {...other}>
+      {!user?.['cognito:groups']?.includes('admins') && (
+        <Box {...other}>
           <List disablePadding sx={{ p: 1 }}>
             {data.filter(item => item.adminOnly === false).map((section, index) => (
               <Fragment key={section.sectionTitle}>
                 <Typography variant='subtitle2' color='gray' fontWeight={700} pl={2} mb={2} mt={index > 0 ? 4 : 0}>
                   {section.sectionTitle}
                 </Typography>
-                {
-                  section.items.map(item =>
-                    <NavItem externalLink={item.externalLink} key={item.title} item={item} />
-                  )
-                }
+                {section.items.map(item => (
+                  <NavItem key={item.title} item={item} />
+                ))}
               </Fragment>
             ))}
           </List>
         </Box>
-      }
-      {
-        user && user['cognito:groups']?.includes('admins') && <Box {...other}>
+      )}
+      {user && user['cognito:groups']?.includes('admins') && (
+        <Box {...other}>
           <List disablePadding sx={{ p: 1 }}>
             {data.map((section, index) => (
               <Fragment key={section.sectionTitle}>
                 <Typography variant='subtitle2' color='gray' fontWeight={700} pl={2} mb={2} mt={index > 0 ? 4 : 0}>
                   {section.sectionTitle}
                 </Typography>
-                {
-                  section.items.map(item =>
-                    <NavItem externalLink={item.externalLink} key={item.title} item={item} />
-                  )
-                }
+                {section.items.map(item => (
+                  <NavItem key={item.title} item={item} />
+                ))}
               </Fragment>
             ))}
           </List>
         </Box>
-      }
+      )}
     </>
   );
 }
@@ -67,11 +61,11 @@ NavItem.propTypes = {
 };
 
 function NavItem({ item }) {
-  const { title, path, icon, info } = item;
+  const { title, path, icon, info, chipText, chipColor, externalLink } = item;
 
   return (
     <>
-      {item.externalLink === false &&
+      {!externalLink && (
         <StyledNavItem
           component={RouterLink}
           to={path}
@@ -81,19 +75,35 @@ function NavItem({ item }) {
               bgcolor: 'action.selected',
               fontWeight: 'fontWeightBold',
             },
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: chipText ? 'none' : 'space-between',  // Ensure even spacing
           }}
         >
-          <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
-
-          <ListItemText sx={{fontSize:16}} disableTypography primary={title} />
-
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
+            <ListItemText sx={{ fontSize: 16 }} disableTypography primary={title} />
+          </Box>
+          {chipText && (
+            <Chip
+              label={chipText}
+              color={chipColor}
+              size="small"
+              sx={{
+                fontWeight: 'bold',
+                mx: '10px'
+              }}
+            />
+          )}
           {info && info}
         </StyledNavItem>
-      }
-      {item.externalLink === true &&
+      )}
+      {externalLink && (
         <StyledNavItem
-          onClick={() => {window.open(path, '_blank');}}
-          target='_blank'
+          onClick={() => {
+            window.open(path, '_blank');
+          }}
+          target="_blank"
           rel="noopener noreferrer"
           sx={{
             '&.active': {
@@ -101,15 +111,29 @@ function NavItem({ item }) {
               bgcolor: 'action.selected',
               fontWeight: 'fontWeightBold',
             },
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',  // Ensure even spacing
           }}
         >
-          <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
-
-          <ListItemText sx={{fontSize:16}} disableTypography primary={title} />
-
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
+            <ListItemText sx={{ fontSize: 16 }} disableTypography primary={title} />
+          </Box>
+          {chipText && (
+            <Chip
+              label={chipText}
+              color={chipColor}
+              size="small"
+              sx={{
+                fontWeight: 'bold',
+                mx: '10px'
+              }}
+            />
+          )}
           {info && info}
         </StyledNavItem>
-      }
+      )}
     </>
   );
 }

--- a/src/layouts/dashboard/nav/config.js
+++ b/src/layouts/dashboard/nav/config.js
@@ -15,7 +15,14 @@ const navConfig = [
     sectionTitle: 'Tools',
     adminOnly: false,
     items: [
-
+      {
+        title: 'collage',
+        path: '/collage',
+        externalLink: false,
+        icon: <PhotoLibrary />,
+        chipText: 'Pro',
+        chipColor: 'info',
+      },
       {
         title: 'search',
         path: '/search',
@@ -27,14 +34,6 @@ const navConfig = [
         path: '/edit',
         externalLink: false,
         icon: <Edit />,
-      },
-      {
-        title: 'collage',
-        path: '/collage',
-        externalLink: false,
-        icon: <PhotoLibrary />,
-        chipText: 'Early Access',
-        chipColor: 'success',
       },
       {
         title: 'Vote',
@@ -73,16 +72,18 @@ const navConfig = [
     adminOnly: false,
     items: [
       {
-        title: 'FAQs',
-        path: '/faq',
-        externalLink: false,
-        icon: <QuestionAnswer />,
-      },
-      {
         title: 'Pro Support',
         path: '/support',
         externalLink: false,
         icon: <SupportAgent />,
+        chipText: 'Pro',
+        chipColor: 'info',
+      },
+      {
+        title: 'FAQs',
+        path: '/faq',
+        externalLink: false,
+        icon: <QuestionAnswer />,
       },
       {
         title: 'Feedback',

--- a/src/layouts/dashboard/nav/config.js
+++ b/src/layouts/dashboard/nav/config.js
@@ -1,5 +1,5 @@
 // component
-import { Article, Ballot, CardGiftcard, Create, DocumentScanner, Edit, Favorite, FolderShared, Grid3x3, Grid4x4, MapsUgc, PhotoAlbum, QuestionAnswer, Search, Settings, Shield, SupportAgent, Upload } from '@mui/icons-material';
+import { Article, Ballot, CardGiftcard, Create, DocumentScanner, Edit, Favorite, FolderShared, Grid3x3, Grid4x4, MapsUgc, PhotoAlbum, PhotoLibrary, QuestionAnswer, Search, Settings, Shield, SupportAgent, Upload } from '@mui/icons-material';
 import SvgColor from '../../../components/svg-color';
 
 // ----------------------------------------------------------------------
@@ -32,7 +32,9 @@ const navConfig = [
         title: 'collage',
         path: '/collage',
         externalLink: false,
-        icon: <Grid4x4 />,
+        icon: <PhotoLibrary />,
+        chipText: 'Early Access',
+        chipColor: 'success',
       },
       {
         title: 'Vote',

--- a/src/pages/EditorNewProjectPage.js
+++ b/src/pages/EditorNewProjectPage.js
@@ -7,6 +7,7 @@ import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import SearchIcon from '@mui/icons-material/Search';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import PhotoLibraryIcon from '@mui/icons-material/PhotoLibrary';
 import BasePage from './BasePage';
 import { createEditorProject } from '../graphql/mutations';
 
@@ -56,7 +57,7 @@ export default function EditorNewProjectPage() {
   // Rest of your component rendering logic remains the same...
   return (
     <BasePage
-      pageTitle="New Project"
+      pageTitle="Meme Tools"
       breadcrumbLinks={[
         { path: "/", name: "Home" },
         { name: "Editor" },
@@ -85,17 +86,6 @@ export default function EditorNewProjectPage() {
                     height: '100%',
                   }}
                 >
-                  <Chip 
-                    label="New!" 
-                    color="success" 
-                    size="small"
-                    sx={{ 
-                      position: 'absolute',
-                      top: 20,
-                      left: 20,
-                      fontWeight: 'bold'
-                    }} 
-                  />
                   <CloudUploadIcon sx={{ fontSize: 60, mb: 2 }} />
                   <Typography variant="h5" component="div" gutterBottom>
                     Upload Image
@@ -114,6 +104,38 @@ export default function EditorNewProjectPage() {
             </label>
           </Grid>
 
+          <Grid item xs={12} sm={6} md={4} lg={3}>
+          <CardActionArea onClick={() => navigate('/collage')}>
+            <Paper
+              elevation={6}
+              sx={{
+                p: 3,
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
+                height: '100%',
+              }}
+            >
+               <Chip 
+                    label="Early Access!" 
+                    color="success" 
+                    size="small"
+                    sx={{ 
+                      position: 'absolute',
+                      top: 20,
+                      left: 20,
+                      fontWeight: 'bold'
+                    }} 
+                  />
+              <PhotoLibraryIcon sx={{ fontSize: 60, mb: 2 }} />
+              <Typography variant="h5" component="div" gutterBottom>
+                Create Collage
+              </Typography>
+              <Typography color="text.secondary">Combine multiple images</Typography>
+            </Paper>
+          </CardActionArea>
+        </Grid>
 
           <Grid item xs={12} sm={6} md={4} lg={3}>
             <CardActionArea onClick={() => navigate('/')}>
@@ -132,7 +154,7 @@ export default function EditorNewProjectPage() {
                 <Typography variant="h5" component="div" gutterBottom>
                   Search Images
                 </Typography>
-                <Typography color="text.secondary">Find 64 million+ on memeSRC</Typography>
+                <Typography color="text.secondary">Find 70 million+ on memeSRC</Typography>
               </Paper>
             </CardActionArea>
           </Grid>

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -213,7 +213,7 @@ const StyledGridContainer = styled(Grid)`
 
 // Theme Defaults
 const defaultTitleText = 'memeSRC';
-const defaultBragText = 'Search 64 million+ screencaps';
+const defaultBragText = 'Search 70 million+ screencaps';
 const defaultFontColor = '#FFFFFF';
 const defaultBackground = `linear-gradient(45deg,
   #5461c8 12.5% /* 1*12.5% */,


### PR DESCRIPTION
# Description

This PR improves the 'discoverability' of the collage tool in early access: 

- Adds and utilizes a new option to show chips on nav bar items (shows "Pro" beside it).
- Adds a homepage 'alert' component account it.
- Adds a 'tools' page section to launch it.

In the future, we could also integrate it as a step in the normal edit flow. 

# Preview

<img width="643" alt="image" src="https://github.com/Vibe-House-LLC/memeSRC/assets/915285/fd4686a9-b13e-4591-b00d-e885956ea9f8">
