### PR TITLE
Collage upload mobile layout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "files.exclude": {
+    "amplify/.config": true,
+    "amplify/**/*-parameters.json": true,
+    "amplify/**/amplify.state": true,
+    "amplify/**/transform.conf.json": true,
+    "amplify/#current-cloud-backend": true,
+    "amplify/backend/amplify-meta.json": true,
+    "amplify/backend/awscloudformation": false
+  }
+}

--- a/amplify/.config/project-config.json
+++ b/amplify/.config/project-config.json
@@ -1,4 +1,7 @@
 {
+  "providers": [
+    "awscloudformation"
+  ],
   "projectName": "memeSRC",
   "version": "3.1",
   "frontend": "javascript",
@@ -10,8 +13,5 @@
       "BuildCommand": "npm run-script build",
       "StartCommand": "npm run-script start"
     }
-  },
-  "providers": [
-    "awscloudformation"
-  ]
+  }
 }

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -103,7 +103,7 @@
         },
         "memesrcAggregateVotes": {
           "deploymentBucketName": "amplify-memesrc-dev-191629-deployment",
-          "s3Key": "amplify-builds/memesrcAggregateVotes-676c357536444c4a6d76-build.zip",
+          "s3Key": "amplify-builds/memesrcAggregateVotes-4546592b4b764a416978-build.zip",
           "secretsPathAmplifyAppId": "d32pnvtwxwtte5",
           "opensearchUser": "davis"
         },

--- a/src/components/collage/components/BulkUploadSection.js
+++ b/src/components/collage/components/BulkUploadSection.js
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { 
   Box, 
   Typography, 
@@ -239,7 +240,10 @@ const BulkUploadSection = ({
   // Scroll functions
   const scrollLeft = (ref) => {
     if (ref.current) {
-      const scrollDistance = Math.min(ref.current.clientWidth * 0.5, 250);
+      // Use a more conservative scroll distance that adapts to container size
+      // but prevents over-scrolling by using smaller increments
+      const containerWidth = ref.current.clientWidth;
+      const scrollDistance = Math.min(containerWidth * 0.3, 150); // 30% of container or 150px max
       ref.current.scrollBy({ left: -scrollDistance, behavior: 'smooth' });
       
       setTimeout(() => {
@@ -250,7 +254,10 @@ const BulkUploadSection = ({
   
   const scrollRight = (ref) => {
     if (ref.current) {
-      const scrollDistance = Math.min(ref.current.clientWidth * 0.5, 250);
+      // Use a more conservative scroll distance that adapts to container size
+      // but prevents over-scrolling by using smaller increments
+      const containerWidth = ref.current.clientWidth;
+      const scrollDistance = Math.min(containerWidth * 0.3, 150); // 30% of container or 150px max
       ref.current.scrollBy({ left: scrollDistance, behavior: 'smooth' });
       
       setTimeout(() => {
@@ -264,8 +271,10 @@ const BulkUploadSection = ({
     if (!ref.current) return;
     
     const { scrollLeft, scrollWidth, clientWidth } = ref.current;
-    const hasLeft = scrollLeft > 5;
-    const hasRight = scrollLeft < scrollWidth - clientWidth - 5;
+    // Use a smaller threshold (1 pixel) to better detect when we're at the edges
+    // This fixes the issue where the left arrow wouldn't disappear after scrolling back to the start
+    const hasLeft = scrollLeft > 1;
+    const hasRight = scrollLeft < scrollWidth - clientWidth - 1;
     
     setLeftScroll(hasLeft);
     setRightScroll(hasRight);
@@ -1113,6 +1122,20 @@ const BulkUploadSection = ({
       )}
     </DisclosureCard>
   );
+};
+
+BulkUploadSection.propTypes = {
+  selectedImages: PropTypes.array.isRequired,
+  addMultipleImages: PropTypes.func.isRequired,
+  panelImageMapping: PropTypes.object.isRequired,
+  updatePanelImageMapping: PropTypes.func.isRequired,
+  panelCount: PropTypes.number.isRequired,
+  selectedTemplate: PropTypes.object,
+  setPanelCount: PropTypes.func,
+  removeImage: PropTypes.func,
+  replaceImage: PropTypes.func,
+  bulkUploadSectionOpen: PropTypes.bool,
+  onBulkUploadSectionToggle: PropTypes.func,
 };
 
 export default BulkUploadSection; 

--- a/src/components/collage/components/CollageLayoutComponents.js
+++ b/src/components/collage/components/CollageLayoutComponents.js
@@ -1,19 +1,13 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { useTheme } from "@mui/material/styles";
 import {
   Box,
-  Grid,
-  Typography,
   Container,
-  Button,
   Stack,
-  Divider,
   useMediaQuery,
-  Collapse,
-  Paper,
-  IconButton
 } from "@mui/material";
-import { Settings, PhotoLibrary, Launch as ExportIcon, ArrowBack, KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
+import { Settings, PhotoLibrary } from "@mui/icons-material";
 
 import CollageSettingsStep from "../steps/CollageSettingsStep";
 import CollageImagesStep from "../steps/CollageImagesStep";
@@ -25,8 +19,7 @@ import DisclosureCard from './DisclosureCard';
 /**
  * Main container for the collage page content
  */
-export const MainContainer = ({ children, isMobile, isMediumScreen }) => {
-  return (
+export const MainContainer = ({ children, isMobile, isMediumScreen }) => 
     <Box component="main" sx={{ 
       flexGrow: 1,
       pb: isMobile ? 3 : 6,
@@ -47,14 +40,18 @@ export const MainContainer = ({ children, isMobile, isMediumScreen }) => {
         {children}
       </Container>
     </Box>
-  );
+;
+
+MainContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+  isMobile: PropTypes.bool.isRequired,
+  isMediumScreen: PropTypes.bool.isRequired,
 };
 
 /**
  * Paper container for the main content
  */
-export const ContentPaper = ({ children, isMobile, sx = {} }) => {
-  return (
+export const ContentPaper = ({ children, isMobile, sx = {} }) => 
     <Box sx={{ 
       width: '100%',
       bgcolor: isMobile ? 'transparent' : 'background.paper',
@@ -64,7 +61,12 @@ export const ContentPaper = ({ children, isMobile, sx = {} }) => {
     }}>
       {children}
     </Box>
-  );
+;
+
+ContentPaper.propTypes = {
+  children: PropTypes.node.isRequired,
+  isMobile: PropTypes.bool.isRequired,
+  sx: PropTypes.object,
 };
 
 /**
@@ -96,10 +98,24 @@ const CollapsibleSettingsSection = ({ settingsStepProps, isMobile }) => {
   );
 };
 
+CollapsibleSettingsSection.propTypes = {
+  settingsStepProps: PropTypes.shape({
+    selectedAspectRatio: PropTypes.number,
+    selectedTemplate: PropTypes.object,
+    panelCount: PropTypes.number.isRequired,
+    borderThickness: PropTypes.number,
+    setBorderThickness: PropTypes.func,
+    setPanelCount: PropTypes.func.isRequired,
+    onAspectRatioChange: PropTypes.func.isRequired,
+    onTemplateChange: PropTypes.func.isRequired,
+  }).isRequired,
+  isMobile: PropTypes.bool.isRequired,
+};
+
 /**
  * Unified layout for the collage tool that adapts to all screen sizes
  */
-export const CollageLayout = ({ settingsStepProps, imagesStepProps, finalImage, setFinalImage, isMobile, onBackToEdit }) => {
+export const CollageLayout = ({ settingsStepProps, imagesStepProps, finalImage, setFinalImage, isMobile }) => {
   const theme = useTheme();
   const isTablet = useMediaQuery(theme.breakpoints.down('md'));
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
@@ -273,4 +289,34 @@ export const CollageLayout = ({ settingsStepProps, imagesStepProps, finalImage, 
       />
     </>
   );
+};
+
+CollageLayout.propTypes = {
+  settingsStepProps: PropTypes.shape({
+    selectedAspectRatio: PropTypes.number,
+    selectedTemplate: PropTypes.object,
+    panelCount: PropTypes.number.isRequired,
+    borderThickness: PropTypes.number,
+    setBorderThickness: PropTypes.func,
+    setPanelCount: PropTypes.func.isRequired,
+    onAspectRatioChange: PropTypes.func.isRequired,
+    onTemplateChange: PropTypes.func.isRequired,
+  }).isRequired,
+  imagesStepProps: PropTypes.shape({
+    selectedImages: PropTypes.array.isRequired,
+    selectedTemplate: PropTypes.object,
+    selectedAspectRatio: PropTypes.number,
+    panelCount: PropTypes.number.isRequired,
+    panelImageMapping: PropTypes.object.isRequired,
+    addMultipleImages: PropTypes.func.isRequired,
+    updatePanelImageMapping: PropTypes.func.isRequired,
+    removeImage: PropTypes.func.isRequired,
+    replaceImage: PropTypes.func.isRequired,
+    bulkUploadSectionOpen: PropTypes.bool.isRequired,
+    onBulkUploadSectionToggle: PropTypes.func.isRequired,
+  }).isRequired,
+  finalImage: PropTypes.string,
+  setFinalImage: PropTypes.func.isRequired,
+  isMobile: PropTypes.bool.isRequired,
+  onBackToEdit: PropTypes.func,
 };

--- a/src/components/collage/components/DynamicCollagePreview.js
+++ b/src/components/collage/components/DynamicCollagePreview.js
@@ -550,6 +550,13 @@ const DynamicCollagePreview = ({
       showFillGuides: false
     });
     
+    // Touch tracking for preventing accidental clicks during scroll
+    const [touchState, setTouchState] = React.useState({
+      startX: null,
+      startY: null,
+      moved: false
+    });
+    
     // Determine the image index using the mapping if available
     const imageIndex = panelId && panelImageMapping[panelId] !== undefined 
       ? panelImageMapping[panelId] 
@@ -802,6 +809,43 @@ const DynamicCollagePreview = ({
       } else {
         enableTransformForPanel(panelId);
       }
+    };
+
+    // Touch handlers for preventing accidental clicks during scroll
+    const handleTouchStart = (e) => {
+      const touch = e.touches[0];
+      setTouchState({
+        startX: touch.clientX,
+        startY: touch.clientY,
+        moved: false
+      });
+    };
+
+    const handleTouchMove = (e) => {
+      if (touchState.startX === null || touchState.startY === null) return;
+      
+      const touch = e.touches[0];
+      const deltaX = Math.abs(touch.clientX - touchState.startX);
+      const deltaY = Math.abs(touch.clientY - touchState.startY);
+      
+      // If movement is more than 10px in any direction, consider it a scroll
+      if (deltaX > 10 || deltaY > 10) {
+        setTouchState(prev => ({ ...prev, moved: true }));
+      }
+    };
+
+    const handleTouchEnd = (e) => {
+      // Only trigger click if there was minimal movement (not a scroll)
+      if (!touchState.moved) {
+        handleRepositionClick(e);
+      }
+      
+      // Reset touch state
+      setTouchState({
+        startX: null,
+        startY: null,
+        moved: false
+      });
     };
 
     // Handle click on overlay - replace when not in edit mode
@@ -1072,7 +1116,9 @@ const DynamicCollagePreview = ({
         <IconButton 
           size="small" 
           onClick={handleRepositionClick}
-          onTouchEnd={handleRepositionClick}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
           sx={{ 
             position: 'absolute', 
             top: 8, 
@@ -1105,35 +1151,86 @@ const DynamicCollagePreview = ({
     );
   };
 
-  const RenderAddButton = ({ index, panelId }) => (
-    <IconButton
-      onClick={(e) => {
-        e.stopPropagation(); // Prevent event bubbling to parent Box
-        if (onPanelClick) {
-          onPanelClick(index, panelId);
-        }
-      }}
-      sx={{
-        width: 64,
-        height: 64,
-        backgroundColor: '#2196F3', // Solid blue background
-        color: '#ffffff',
-        border: '3px solid #ffffff',
-        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.2)',
-        '&:hover': {
-          backgroundColor: '#1976D2',
-          transform: 'scale(1.1)',
-          boxShadow: '0 6px 16px rgba(0, 0, 0, 0.5), 0 3px 6px rgba(0, 0, 0, 0.3)',
-        },
-        '&:active': {
-          transform: 'scale(1.05)',
-        },
-        transition: 'all 0.2s ease-in-out',
-      }}
-    >
-      <Add sx={{ fontSize: 32 }} />
-    </IconButton>
-  );
+  const RenderAddButton = ({ index, panelId }) => {
+    // Touch tracking for preventing accidental clicks during scroll
+    const [touchState, setTouchState] = React.useState({
+      startX: null,
+      startY: null,
+      moved: false
+    });
+
+    const handleAddClick = (e) => {
+      e.stopPropagation(); // Prevent event bubbling to parent Box
+      if (onPanelClick) {
+        onPanelClick(index, panelId);
+      }
+    };
+
+    // Touch handlers for preventing accidental clicks during scroll
+    const handleTouchStart = (e) => {
+      const touch = e.touches[0];
+      setTouchState({
+        startX: touch.clientX,
+        startY: touch.clientY,
+        moved: false
+      });
+    };
+
+    const handleTouchMove = (e) => {
+      if (touchState.startX === null || touchState.startY === null) return;
+      
+      const touch = e.touches[0];
+      const deltaX = Math.abs(touch.clientX - touchState.startX);
+      const deltaY = Math.abs(touch.clientY - touchState.startY);
+      
+      // If movement is more than 10px in any direction, consider it a scroll
+      if (deltaX > 10 || deltaY > 10) {
+        setTouchState(prev => ({ ...prev, moved: true }));
+      }
+    };
+
+    const handleTouchEnd = (e) => {
+      // Only trigger click if there was minimal movement (not a scroll)
+      if (!touchState.moved) {
+        handleAddClick(e);
+      }
+      
+      // Reset touch state
+      setTouchState({
+        startX: null,
+        startY: null,
+        moved: false
+      });
+    };
+
+    return (
+      <IconButton
+        onClick={handleAddClick}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        sx={{
+          width: 64,
+          height: 64,
+          backgroundColor: '#2196F3', // Solid blue background
+          color: '#ffffff',
+          border: '3px solid #ffffff',
+          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.2)',
+          '&:hover': {
+            backgroundColor: '#1976D2',
+            transform: 'scale(1.1)',
+            boxShadow: '0 6px 16px rgba(0, 0, 0, 0.5), 0 3px 6px rgba(0, 0, 0, 0.3)',
+          },
+          '&:active': {
+            transform: 'scale(1.05)',
+          },
+          transition: 'all 0.2s ease-in-out',
+        }}
+      >
+        <Add sx={{ fontSize: 32 }} />
+      </IconButton>
+    );
+  };
 
   // Don't render anything if we don't have a template or layout config
   if (!selectedTemplate || !layoutConfig) return null;

--- a/src/pages/CollagePage.js
+++ b/src/pages/CollagePage.js
@@ -447,7 +447,8 @@ export default function CollagePage() {
                 alignItems: 'center',
                 fontWeight: '700', 
                 mb: isMobile ? 0.5 : 0.75,
-                pl: isMobile ? 0 : 0,
+                pl: isMobile ? 0.5 : 0,
+                ml: isMobile ? 0 : -0.5,
                 color: '#fff',
                 fontSize: isMobile ? '2.2rem' : '2.5rem',
                 textShadow: '0px 2px 4px rgba(0,0,0,0.15)'
@@ -457,8 +458,8 @@ export default function CollagePage() {
               </Typography>
               <Typography variant="subtitle1" sx={{ 
                 color: 'text.secondary',
-                mb: isMobile ? 1 : 1.5,
-                pl: isMobile ? 0 : 5,
+                mb: isMobile ? 2 : 1.5,
+                pl: isMobile ? 1 : 0,
                 maxWidth: '85%'
               }}>
                 Merge images together to create multi-panel memes


### PR DESCRIPTION
This PR makes some layout tweaks to the new Collage Tool page. Specifically the title/subtitle section left padding and some spacing below that. On mobile the text and containers should all have the same starting point.

This also fixes the "edit/accept edit" buttons in each panel to not click when you're scrolling on mobile. Before, if you started the scroll on top of one of those buttons it would "click" the button during the scroll. Now you specifically have to tap the button on mobile and it will not be selected when the user is just trying to scroll up/down the page. 