### PR TITLE
Create branch for issue 414 fix

### DIFF
--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -433,12 +433,8 @@ const CanvasCollagePreview = ({
         : 'rgba(0,0,0,0.3)';
       ctx.fillRect(x, y, width, height);
       
-      // Remove hover effect for empty panels to prevent interference with collage generation
-      // Hover effects should be handled by CSS or UI overlays, not drawn on the canvas
-      // if (isHovered && !hasImage) {
-      //   ctx.fillStyle = 'rgba(0,0,0,0.4)';
-      //   ctx.fillRect(x, y, width, height);
-      // }
+      // Note: Hover effects are now handled by CSS overlays, not canvas drawing
+      // This ensures they don't interfere with collage generation
       
       if (hasImage) {
         const img = loadedImages[imageIndex];
@@ -486,13 +482,6 @@ const CanvasCollagePreview = ({
           );
           
           ctx.restore();
-          
-          // Remove hover effect for images to prevent darkening during collage generation
-          // Hover effects should be handled by CSS or UI overlays, not drawn on the canvas
-          // if (isHovered && !isInTransformMode) {
-          //   ctx.fillStyle = 'rgba(0, 0, 0, 0.1)';
-          //   ctx.fillRect(x, y, width, height);
-          // }
         }
       } else {
         // Draw add icon for empty panels
@@ -622,7 +611,6 @@ const CanvasCollagePreview = ({
     panelTransforms, 
     borderPixels, 
     borderColor, 
-    hoveredPanel, 
     selectedPanel, 
     isTransformMode,
     panelTexts,
@@ -1223,6 +1211,37 @@ const CanvasCollagePreview = ({
               <TextFields sx={{ fontSize: 16 }} />
             </IconButton>
           </Box>
+        );
+      })}
+
+      {/* Hover overlays - positioned over canvas panels */}
+      {panelRects.map((rect, index) => {
+        const { panelId } = rect;
+        const imageIndex = panelImageMapping[panelId];
+        const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
+        const isHovered = hoveredPanel === index;
+        const isInTransformMode = isTransformMode[panelId];
+        
+        // Only show hover overlay when actually hovered and not in transform mode
+        if (!isHovered || isInTransformMode) return null;
+        
+        return (
+          <Box
+            key={`hover-overlay-${panelId}`}
+            sx={{
+              position: 'absolute',
+              top: rect.y,
+              left: rect.x,
+              width: rect.width,
+              height: rect.height,
+              backgroundColor: hasImage 
+                ? 'rgba(0, 0, 0, 0.1)' // Light overlay for images
+                : 'rgba(0, 0, 0, 0.4)', // Darker overlay for empty panels
+              pointerEvents: 'none', // Don't interfere with mouse events
+              transition: 'backgroundColor 0.2s ease-in-out',
+              zIndex: 5, // Above canvas, below control buttons
+            }}
+          />
         );
       })}
 

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -433,11 +433,12 @@ const CanvasCollagePreview = ({
         : 'rgba(0,0,0,0.3)';
       ctx.fillRect(x, y, width, height);
       
-      // Draw hover effect
-      if (isHovered && !hasImage) {
-        ctx.fillStyle = 'rgba(0,0,0,0.4)';
-        ctx.fillRect(x, y, width, height);
-      }
+      // Remove hover effect for empty panels to prevent interference with collage generation
+      // Hover effects should be handled by CSS or UI overlays, not drawn on the canvas
+      // if (isHovered && !hasImage) {
+      //   ctx.fillStyle = 'rgba(0,0,0,0.4)';
+      //   ctx.fillRect(x, y, width, height);
+      // }
       
       if (hasImage) {
         const img = loadedImages[imageIndex];
@@ -486,11 +487,12 @@ const CanvasCollagePreview = ({
           
           ctx.restore();
           
-          // Draw hover effect for images
-          if (isHovered && !isInTransformMode) {
-            ctx.fillStyle = 'rgba(0, 0, 0, 0.1)';
-            ctx.fillRect(x, y, width, height);
-          }
+          // Remove hover effect for images to prevent darkening during collage generation
+          // Hover effects should be handled by CSS or UI overlays, not drawn on the canvas
+          // if (isHovered && !isInTransformMode) {
+          //   ctx.fillStyle = 'rgba(0, 0, 0, 0.1)';
+          //   ctx.fillRect(x, y, width, height);
+          // }
         }
       } else {
         // Draw add icon for empty panels

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -760,6 +760,15 @@ const CanvasCollagePreview = ({
     setIsDragging(false);
   }, []);
 
+  const handleMouseLeave = useCallback(() => {
+    // Clear hover state when mouse leaves canvas
+    setHoveredPanel(null);
+    const canvas = canvasRef.current;
+    if (canvas) {
+      canvas.style.cursor = 'default';
+    }
+  }, []);
+
   const handleWheel = useCallback((e) => {
     if (selectedPanel !== null) {
       const panel = panelRects[selectedPanel];
@@ -1139,6 +1148,7 @@ const CanvasCollagePreview = ({
         onMouseMove={handleMouseMove}
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
         onWheel={handleWheel}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}


### PR DESCRIPTION
The session focused on resolving a collage mouse-over issue in `src/components/collage/components/CanvasCollagePreview.js`.

*   **Initial Fix**: Canvas-drawn hover effects were removed from the `drawCanvas` function.
    *   Previously, `ctx.fillRect` was used to draw a darkening overlay on hover for both image and empty panels. This caused the overlay to be included in the final collage export, darkening frames.
    *   Removing these lines ensured the canvas only contained the intended collage content.
*   **Dependency Update**: The `hoveredPanel` state was removed from the dependency array of the `drawCanvas` function, as it was no longer used for canvas drawing.
*   **Enhanced Hover Implementation**: CSS-based `Box` overlays were introduced to provide visual hover feedback.
    *   These overlays are absolutely positioned over the canvas panels, using `backgroundColor` with varying opacity (0.1 for images, 0.4 for empty panels).
    *   `pointerEvents: 'none'` was set to prevent interference with mouse events on the canvas itself.
    *   A `transition` was added for smooth visual effects, and `zIndex` was managed for proper layering.
*   **Robustness**: A `handleMouseLeave` function was added to the canvas `onMouseLeave` prop.
    *   This function clears the `hoveredPanel` state and resets the cursor, preventing stuck hover states when the mouse exits the canvas area.