### PR TITLE
Resolve collage zooming issue

### DIFF
--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -784,13 +784,13 @@ const CanvasCollagePreview = ({
       cursorY >= panel.y && cursorY <= panel.y + panel.height
     );
     
-    // Only proceed if cursor is over a panel with an image
+    // Only proceed if cursor is over a panel with an image AND transform mode is enabled
     if (hoveredPanelIndex >= 0) {
       const panel = panelRects[hoveredPanelIndex];
       const imageIndex = panelImageMapping[panel.panelId];
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
-      if (hasImage) {
+      if (hasImage && isTransformMode[panel.panelId]) {
         // Auto-select this panel for zoom operation
         if (selectedPanel !== hoveredPanelIndex) {
           setSelectedPanel(hoveredPanelIndex);
@@ -886,7 +886,7 @@ const CanvasCollagePreview = ({
         }
       }
     }
-  }, [panelRects, panelImageMapping, loadedImages, selectedPanel, panelTransforms, updatePanelTransform, setSelectedPanel]);
+  }, [panelRects, panelImageMapping, loadedImages, selectedPanel, panelTransforms, updatePanelTransform, setSelectedPanel, isTransformMode]);
 
   // Helper function to get distance between two touch points
   const getTouchDistance = useCallback((touches) => {
@@ -947,7 +947,7 @@ const CanvasCollagePreview = ({
       const imageIndex = panelImageMapping[panel.panelId];
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
-      if (panel && hasImage) {
+      if (panel && hasImage && isTransformMode[panel.panelId]) {
         e.preventDefault(); // Prevent scrolling
         const distance = getTouchDistance(touches);
         const currentTransform = panelTransforms[panel.panelId] || { scale: 1, positionX: 0, positionY: 0 };
@@ -1045,7 +1045,7 @@ const CanvasCollagePreview = ({
       const imageIndex = panelImageMapping[panel.panelId];
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
-      if (panel && hasImage) {
+      if (panel && hasImage && isTransformMode[panel.panelId]) {
         e.preventDefault(); // Prevent scrolling
         
         const currentDistance = getTouchDistance(touches);

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -782,59 +782,89 @@ const CanvasCollagePreview = ({
         const img = loadedImages[imageIndex];
         
         if (img && updatePanelTransform) {
+          // Get cursor position relative to the canvas
+          const canvas = canvasRef.current;
+          const rect = canvas.getBoundingClientRect();
+          const cursorX = e.clientX - rect.left;
+          const cursorY = e.clientY - rect.top;
+          
+          // Calculate cursor position relative to the panel
+          const panelCursorX = cursorX - panel.x;
+          const panelCursorY = cursorY - panel.y;
+          
           // Calculate the minimum scale needed to cover the panel (same as initial scale logic)
           const imageAspectRatio = img.naturalWidth / img.naturalHeight;
           const panelAspectRatio = panel.width / panel.height;
           
-                     let minScale;
-           if (imageAspectRatio > panelAspectRatio) {
-             // Image is wider than panel, scale to fit height
-             minScale = 1; // The initial scale already fits height, so 1x user scale is minimum
-           } else {
-             // Image is taller than panel, scale to fit width  
-             minScale = 1; // The initial scale already fits width, so 1x user scale is minimum
-           }
+          let minScale;
+          if (imageAspectRatio > panelAspectRatio) {
+            // Image is wider than panel, scale to fit height
+            minScale = 1; // The initial scale already fits height, so 1x user scale is minimum
+          } else {
+            // Image is taller than panel, scale to fit width  
+            minScale = 1; // The initial scale already fits width, so 1x user scale is minimum
+          }
           
-                     const proposedScale = currentTransform.scale * scaleChange;
-           const newScale = Math.max(minScale, Math.min(5, proposedScale));
-           
-           // Recalculate position bounds with new scale and adjust position if needed
-           const initialScale = imageAspectRatio > panelAspectRatio 
-             ? panel.height / img.naturalHeight 
-             : panel.width / img.naturalWidth;
-           const finalScale = initialScale * newScale;
-           const scaledWidth = img.naturalWidth * finalScale;
-           const scaledHeight = img.naturalHeight * finalScale;
-           const centerOffsetX = (panel.width - scaledWidth) / 2;
-           const centerOffsetY = (panel.height - scaledHeight) / 2;
-           
-           let adjustedPositionX = currentTransform.positionX;
-           let adjustedPositionY = currentTransform.positionY;
-           
-           // Check and adjust horizontal position if needed
-           if (scaledWidth > panel.width) {
-             const maxPositionX = -centerOffsetX;
-             const minPositionX = panel.width - scaledWidth - centerOffsetX;
-             adjustedPositionX = Math.max(minPositionX, Math.min(maxPositionX, currentTransform.positionX));
-           } else {
-             adjustedPositionX = 0;
-           }
-           
-           // Check and adjust vertical position if needed
-           if (scaledHeight > panel.height) {
-             const maxPositionY = -centerOffsetY;
-             const minPositionY = panel.height - scaledHeight - centerOffsetY;
-             adjustedPositionY = Math.max(minPositionY, Math.min(maxPositionY, currentTransform.positionY));
-           } else {
-             adjustedPositionY = 0;
-           }
+          const proposedScale = currentTransform.scale * scaleChange;
+          const newScale = Math.max(minScale, Math.min(5, proposedScale));
           
-           updatePanelTransform(panel.panelId, {
-             ...currentTransform,
-             scale: newScale,
-             positionX: adjustedPositionX,
-             positionY: adjustedPositionY
-           });
+          // Calculate initial scale and current image dimensions
+          const initialScale = imageAspectRatio > panelAspectRatio 
+            ? panel.height / img.naturalHeight 
+            : panel.width / img.naturalWidth;
+          const currentFinalScale = initialScale * currentTransform.scale;
+          const newFinalScale = initialScale * newScale;
+          const currentScaledWidth = img.naturalWidth * currentFinalScale;
+          const currentScaledHeight = img.naturalHeight * currentFinalScale;
+          const newScaledWidth = img.naturalWidth * newFinalScale;
+          const newScaledHeight = img.naturalHeight * newFinalScale;
+          
+          // Calculate current center offsets
+          const currentCenterOffsetX = (panel.width - currentScaledWidth) / 2;
+          const currentCenterOffsetY = (panel.height - currentScaledHeight) / 2;
+          const newCenterOffsetX = (panel.width - newScaledWidth) / 2;
+          const newCenterOffsetY = (panel.height - newScaledHeight) / 2;
+          
+          // Calculate the point on the image that corresponds to the cursor position (before scaling)
+          const currentImageX = currentCenterOffsetX + currentTransform.positionX;
+          const currentImageY = currentCenterOffsetY + currentTransform.positionY;
+          const pointOnImageX = (panelCursorX - currentImageX) / currentFinalScale;
+          const pointOnImageY = (panelCursorY - currentImageY) / currentFinalScale;
+          
+          // Calculate new position so the same point on the image stays under the cursor
+          const newImageX = panelCursorX - (pointOnImageX * newFinalScale);
+          const newImageY = panelCursorY - (pointOnImageY * newFinalScale);
+          const newPositionX = newImageX - newCenterOffsetX;
+          const newPositionY = newImageY - newCenterOffsetY;
+          
+          // Calculate bounds to prevent white space and clamp the new position
+          let minPositionX, maxPositionX, minPositionY, maxPositionY;
+          
+          if (newScaledWidth > panel.width) {
+            maxPositionX = -newCenterOffsetX;
+            minPositionX = panel.width - newScaledWidth - newCenterOffsetX;
+          } else {
+            minPositionX = 0;
+            maxPositionX = 0;
+          }
+          
+          if (newScaledHeight > panel.height) {
+            maxPositionY = -newCenterOffsetY;
+            minPositionY = panel.height - newScaledHeight - newCenterOffsetY;
+          } else {
+            minPositionY = 0;
+            maxPositionY = 0;
+          }
+          
+          const clampedPositionX = Math.max(minPositionX, Math.min(maxPositionX, newPositionX));
+          const clampedPositionY = Math.max(minPositionY, Math.min(maxPositionY, newPositionY));
+          
+          updatePanelTransform(panel.panelId, {
+            ...currentTransform,
+            scale: newScale,
+            positionX: clampedPositionX,
+            positionY: clampedPositionY
+          });
         }
       }
     }
@@ -998,6 +1028,17 @@ const CanvasCollagePreview = ({
         const scaleRatio = currentDistance / touchStartDistance;
         const newScale = touchStartScale * scaleRatio;
         
+        // Get the center point of the pinch gesture
+        const pinchCenter = getTouchCenter(touches);
+        const canvas = canvasRef.current;
+        const rect = canvas.getBoundingClientRect();
+        const pinchCenterX = pinchCenter.x - rect.left;
+        const pinchCenterY = pinchCenter.y - rect.top;
+        
+        // Calculate pinch center position relative to the panel
+        const panelPinchX = pinchCenterX - panel.x;
+        const panelPinchY = pinchCenterY - panel.y;
+        
         const currentTransform = panelTransforms[panel.panelId] || { scale: 1, positionX: 0, positionY: 0 };
         const imageIndex = panelImageMapping[panel.panelId];
         const img = loadedImages[imageIndex];
@@ -1010,47 +1051,67 @@ const CanvasCollagePreview = ({
           const minScale = 1;
           const clampedScale = Math.max(minScale, Math.min(5, newScale));
           
-          // Recalculate position bounds with new scale
+          // Calculate initial scale and current image dimensions
           const initialScale = imageAspectRatio > panelAspectRatio 
             ? panel.height / img.naturalHeight 
             : panel.width / img.naturalWidth;
-          const finalScale = initialScale * clampedScale;
-          const scaledWidth = img.naturalWidth * finalScale;
-          const scaledHeight = img.naturalHeight * finalScale;
-          const centerOffsetX = (panel.width - scaledWidth) / 2;
-          const centerOffsetY = (panel.height - scaledHeight) / 2;
+          const currentFinalScale = initialScale * currentTransform.scale;
+          const newFinalScale = initialScale * clampedScale;
+          const currentScaledWidth = img.naturalWidth * currentFinalScale;
+          const currentScaledHeight = img.naturalHeight * currentFinalScale;
+          const newScaledWidth = img.naturalWidth * newFinalScale;
+          const newScaledHeight = img.naturalHeight * newFinalScale;
           
-          let adjustedPositionX = currentTransform.positionX;
-          let adjustedPositionY = currentTransform.positionY;
+          // Calculate current center offsets
+          const currentCenterOffsetX = (panel.width - currentScaledWidth) / 2;
+          const currentCenterOffsetY = (panel.height - currentScaledHeight) / 2;
+          const newCenterOffsetX = (panel.width - newScaledWidth) / 2;
+          const newCenterOffsetY = (panel.height - newScaledHeight) / 2;
           
-          // Check and adjust horizontal position if needed
-          if (scaledWidth > panel.width) {
-            const maxPositionX = -centerOffsetX;
-            const minPositionX = panel.width - scaledWidth - centerOffsetX;
-            adjustedPositionX = Math.max(minPositionX, Math.min(maxPositionX, currentTransform.positionX));
+          // Calculate the point on the image that corresponds to the pinch center (before scaling)
+          const currentImageX = currentCenterOffsetX + currentTransform.positionX;
+          const currentImageY = currentCenterOffsetY + currentTransform.positionY;
+          const pointOnImageX = (panelPinchX - currentImageX) / currentFinalScale;
+          const pointOnImageY = (panelPinchY - currentImageY) / currentFinalScale;
+          
+          // Calculate new position so the same point on the image stays under the pinch center
+          const newImageX = panelPinchX - (pointOnImageX * newFinalScale);
+          const newImageY = panelPinchY - (pointOnImageY * newFinalScale);
+          const newPositionX = newImageX - newCenterOffsetX;
+          const newPositionY = newImageY - newCenterOffsetY;
+          
+          // Calculate bounds to prevent white space and clamp the new position
+          let minPositionX, maxPositionX, minPositionY, maxPositionY;
+          
+          if (newScaledWidth > panel.width) {
+            maxPositionX = -newCenterOffsetX;
+            minPositionX = panel.width - newScaledWidth - newCenterOffsetX;
           } else {
-            adjustedPositionX = 0;
+            minPositionX = 0;
+            maxPositionX = 0;
           }
           
-          // Check and adjust vertical position if needed
-          if (scaledHeight > panel.height) {
-            const maxPositionY = -centerOffsetY;
-            const minPositionY = panel.height - scaledHeight - centerOffsetY;
-            adjustedPositionY = Math.max(minPositionY, Math.min(maxPositionY, currentTransform.positionY));
+          if (newScaledHeight > panel.height) {
+            maxPositionY = -newCenterOffsetY;
+            minPositionY = panel.height - newScaledHeight - newCenterOffsetY;
           } else {
-            adjustedPositionY = 0;
+            minPositionY = 0;
+            maxPositionY = 0;
           }
+          
+          const clampedPositionX = Math.max(minPositionX, Math.min(maxPositionX, newPositionX));
+          const clampedPositionY = Math.max(minPositionY, Math.min(maxPositionY, newPositionY));
           
           updatePanelTransform(panel.panelId, {
             ...currentTransform,
             scale: clampedScale,
-            positionX: adjustedPositionX,
-            positionY: adjustedPositionY
+            positionX: clampedPositionX,
+            positionY: clampedPositionY
           });
         }
       }
     }
-  }, [isDragging, selectedPanel, panelRects, isTransformMode, dragStart, panelTransforms, panelImageMapping, loadedImages, updatePanelTransform, touchStartDistance, touchStartScale, getTouchDistance]);
+  }, [isDragging, selectedPanel, panelRects, isTransformMode, dragStart, panelTransforms, panelImageMapping, loadedImages, updatePanelTransform, touchStartDistance, touchStartScale, getTouchDistance, getTouchCenter]);
 
   const handleTouchEnd = useCallback((e) => {
     setIsDragging(false);

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -774,6 +774,14 @@ const CanvasCollagePreview = ({
     const canvas = canvasRef.current;
     if (!canvas) return;
     
+    // Check if any panel has transform mode enabled
+    const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
+    
+    // If any panel is in transform mode, prevent page scrolling
+    if (anyPanelInTransformMode) {
+      e.preventDefault();
+    }
+    
     const rect = canvas.getBoundingClientRect();
     const cursorX = e.clientX - rect.left;
     const cursorY = e.clientY - rect.top;
@@ -784,7 +792,7 @@ const CanvasCollagePreview = ({
       cursorY >= panel.y && cursorY <= panel.y + panel.height
     );
     
-    // Only proceed if cursor is over a panel with an image AND transform mode is enabled
+    // Only proceed with zoom if cursor is over a panel with an image AND transform mode is enabled
     if (hoveredPanelIndex >= 0) {
       const panel = panelRects[hoveredPanelIndex];
       const imageIndex = panelImageMapping[panel.panelId];
@@ -795,8 +803,6 @@ const CanvasCollagePreview = ({
         if (selectedPanel !== hoveredPanelIndex) {
           setSelectedPanel(hoveredPanelIndex);
         }
-        
-        e.preventDefault();
         
         const scaleChange = e.deltaY > 0 ? 0.9 : 1.1;
         const currentTransform = panelTransforms[panel.panelId] || { scale: 1, positionX: 0, positionY: 0 };
@@ -913,6 +919,14 @@ const CanvasCollagePreview = ({
     const canvas = canvasRef.current;
     if (!canvas) return;
     
+    // Check if any panel has transform mode enabled
+    const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
+    
+    // If any panel is in transform mode, prevent page scrolling when touching the canvas
+    if (anyPanelInTransformMode) {
+      e.preventDefault();
+    }
+    
     const rect = canvas.getBoundingClientRect();
     const touches = Array.from(e.touches);
     
@@ -933,7 +947,6 @@ const CanvasCollagePreview = ({
         
         // Check if this panel is in transform mode
         if (isTransformMode[clickedPanel.panelId]) {
-          e.preventDefault(); // Prevent scrolling
           setIsDragging(true);
           setDragStart({ x, y });
         } else if (onPanelClick) {
@@ -948,7 +961,6 @@ const CanvasCollagePreview = ({
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
       if (panel && hasImage && isTransformMode[panel.panelId]) {
-        e.preventDefault(); // Prevent scrolling
         const distance = getTouchDistance(touches);
         const currentTransform = panelTransforms[panel.panelId] || { scale: 1, positionX: 0, positionY: 0 };
         
@@ -963,6 +975,14 @@ const CanvasCollagePreview = ({
     const canvas = canvasRef.current;
     if (!canvas) return;
     
+    // Check if any panel has transform mode enabled
+    const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
+    
+    // If any panel is in transform mode, prevent page scrolling during touch moves on canvas
+    if (anyPanelInTransformMode) {
+      e.preventDefault();
+    }
+    
     const rect = canvas.getBoundingClientRect();
     const touches = Array.from(e.touches);
     
@@ -970,8 +990,6 @@ const CanvasCollagePreview = ({
       // Single touch drag
       const panel = panelRects[selectedPanel];
       if (panel && isTransformMode[panel.panelId]) {
-        e.preventDefault(); // Prevent scrolling
-        
         const touch = touches[0];
         const x = touch.clientX - rect.left;
         const y = touch.clientY - rect.top;
@@ -1046,8 +1064,6 @@ const CanvasCollagePreview = ({
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
       if (panel && hasImage && isTransformMode[panel.panelId]) {
-        e.preventDefault(); // Prevent scrolling
-        
         const currentDistance = getTouchDistance(touches);
         const scaleRatio = currentDistance / touchStartDistance;
         const newScale = touchStartScale * scaleRatio;

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -838,7 +838,10 @@ const CanvasCollagePreview = ({
           const newPositionY = newImageY - newCenterOffsetY;
           
           // Calculate bounds to prevent white space and clamp the new position
-          let minPositionX, maxPositionX, minPositionY, maxPositionY;
+          let minPositionX;
+          let maxPositionX;
+          let minPositionY;
+          let maxPositionY;
           
           if (newScaledWidth > panel.width) {
             maxPositionX = -newCenterOffsetX;
@@ -1081,7 +1084,10 @@ const CanvasCollagePreview = ({
           const newPositionY = newImageY - newCenterOffsetY;
           
           // Calculate bounds to prevent white space and clamp the new position
-          let minPositionX, maxPositionX, minPositionY, maxPositionY;
+          let minPositionX;
+          let maxPositionX;
+          let minPositionY;
+          let maxPositionY;
           
           if (newScaledWidth > panel.width) {
             maxPositionX = -newCenterOffsetX;


### PR DESCRIPTION
## Fixed collage zooming to zoom from interaction point

Fixes issue #415: 

- https://github.com/Vibe-House-LLC/memeSRC/issues/415

**What changed:**
- Collage now zooms from cursor/pinch point instead of image center
- Updated `CanvasCollagePreview.js` zoom behavior for both mouse wheel and touch gestures

**Implementation details:**
- Modified `handleWheel` to calculate cursor position relative to canvas/panel
- Updated `handleTouchMove` to use pinch gesture center point via `getTouchCenter`
- Added proper bounds checking to prevent whitespace after zoom-from-point calculation
- Fixed ESLint `one-var` rule violations by splitting variable declarations

**Result:** Users now get the expected zoom behavior where the point under their cursor/finger stays stationary during zoom.