### PR TITLE
Fix behavior while repositioning collage image on mobile

### DIFF
--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -779,27 +779,21 @@ const CanvasCollagePreview = ({
     const cursorX = e.clientX - rect.left;
     const cursorY = e.clientY - rect.top;
     
-    // Check if any panel has transform mode enabled
-    const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
-    
     // Find which panel is under the cursor
     const hoveredPanelIndex = panelRects.findIndex(panel => 
       cursorX >= panel.x && cursorX <= panel.x + panel.width &&
       cursorY >= panel.y && cursorY <= panel.y + panel.height
     );
     
-    // Prevent page scrolling when scrolling over an image IF any panel has transform mode enabled
+    // Only proceed with zoom if cursor is over a panel with an image AND this specific panel has transform mode enabled
     if (hoveredPanelIndex >= 0) {
       const panel = panelRects[hoveredPanelIndex];
       const imageIndex = panelImageMapping[panel.panelId];
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
-      if (hasImage && anyPanelInTransformMode) {
-        e.preventDefault();
-      }
-      
-      // Only proceed with actual zoom if this specific panel has transform mode enabled
       if (hasImage && isTransformMode[panel.panelId]) {
+        // Prevent page scrolling only when actually zooming an image in transform mode
+        e.preventDefault();
         // Auto-select this panel for zoom operation
         if (selectedPanel !== hoveredPanelIndex) {
           setSelectedPanel(hoveredPanelIndex);
@@ -939,18 +933,12 @@ const CanvasCollagePreview = ({
         const imageIndex = panelImageMapping[clickedPanel.panelId];
         const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
         
-        // Check if any panel has transform mode enabled
-        const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
-        
         setSelectedPanel(clickedPanelIndex);
         
-        // Prevent page scrolling when touching an image IF any panel has transform mode enabled
-        if (hasImage && anyPanelInTransformMode) {
-          e.preventDefault();
-        }
-        
-        // Check if this specific panel is in transform mode for drag interactions
+        // Check if this specific panel is in transform mode
         if (hasImage && isTransformMode[clickedPanel.panelId]) {
+          // Prevent page scrolling only when touching an image in transform mode
+          e.preventDefault();
           setIsDragging(true);
           setDragStart({ x, y });
         } else if (onPanelClick) {
@@ -984,22 +972,15 @@ const CanvasCollagePreview = ({
     const rect = canvas.getBoundingClientRect();
     const touches = Array.from(e.touches);
     
-    // Check if any panel has transform mode enabled
-    const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
-    
     if (touches.length === 1 && isDragging && selectedPanel !== null) {
       // Single touch drag
       const panel = panelRects[selectedPanel];
       const imageIndex = panelImageMapping[panel.panelId];
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
-      // Prevent page scrolling when dragging an image IF any panel has transform mode enabled
-      if (hasImage && anyPanelInTransformMode) {
-        e.preventDefault();
-      }
-      
       if (panel && hasImage && isTransformMode[panel.panelId]) {
-        // Only perform actual drag operations on panels in transform mode
+        // Prevent page scrolling only when dragging an image in transform mode
+        e.preventDefault();
         const touch = touches[0];
         const x = touch.clientX - rect.left;
         const y = touch.clientY - rect.top;

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -930,11 +930,13 @@ const CanvasCollagePreview = ({
       
       if (clickedPanelIndex >= 0) {
         const clickedPanel = panelRects[clickedPanelIndex];
+        const imageIndex = panelImageMapping[clickedPanel.panelId];
+        const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
         setSelectedPanel(clickedPanelIndex);
         
-        // Check if this panel is in transform mode
-        if (isTransformMode[clickedPanel.panelId]) {
-          // Only prevent page scrolling when touching a panel in transform mode
+        // Check if this panel is in transform mode AND has an image
+        if (hasImage && isTransformMode[clickedPanel.panelId]) {
+          // Only prevent page scrolling when touching a panel with image in transform mode
           e.preventDefault();
           setIsDragging(true);
           setDragStart({ x, y });
@@ -972,8 +974,11 @@ const CanvasCollagePreview = ({
     if (touches.length === 1 && isDragging && selectedPanel !== null) {
       // Single touch drag
       const panel = panelRects[selectedPanel];
-      if (panel && isTransformMode[panel.panelId]) {
-        // Only prevent page scrolling when dragging a panel in transform mode
+      const imageIndex = panelImageMapping[panel.panelId];
+      const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
+      
+      if (panel && hasImage && isTransformMode[panel.panelId]) {
+        // Only prevent page scrolling when dragging a panel with image in transform mode
         e.preventDefault();
         const touch = touches[0];
         const x = touch.clientX - rect.left;
@@ -983,7 +988,6 @@ const CanvasCollagePreview = ({
         const deltaY = y - dragStart.y;
         
         const currentTransform = panelTransforms[panel.panelId] || { scale: 1, positionX: 0, positionY: 0 };
-        const imageIndex = panelImageMapping[panel.panelId];
         const img = loadedImages[imageIndex];
         
         if (img && updatePanelTransform) {
@@ -1249,7 +1253,7 @@ const CanvasCollagePreview = ({
           width: '100%',
           height: 'auto',
           border: `1px solid ${theme.palette.divider}`,
-          touchAction: 'none', // Prevent default touch behaviors
+          touchAction: 'pan-y', // Allow vertical scrolling, prevent horizontal pan and zoom
         }}
       />
       

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -779,21 +779,27 @@ const CanvasCollagePreview = ({
     const cursorX = e.clientX - rect.left;
     const cursorY = e.clientY - rect.top;
     
+    // Check if any panel has transform mode enabled
+    const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
+    
     // Find which panel is under the cursor
     const hoveredPanelIndex = panelRects.findIndex(panel => 
       cursorX >= panel.x && cursorX <= panel.x + panel.width &&
       cursorY >= panel.y && cursorY <= panel.y + panel.height
     );
     
-    // Only proceed with zoom if cursor is over a panel with an image AND transform mode is enabled
+    // Prevent page scrolling when scrolling over an image IF any panel has transform mode enabled
     if (hoveredPanelIndex >= 0) {
       const panel = panelRects[hoveredPanelIndex];
       const imageIndex = panelImageMapping[panel.panelId];
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
-      if (hasImage && isTransformMode[panel.panelId]) {
-        // Only prevent page scrolling when we're actually zooming an image
+      if (hasImage && anyPanelInTransformMode) {
         e.preventDefault();
+      }
+      
+      // Only proceed with actual zoom if this specific panel has transform mode enabled
+      if (hasImage && isTransformMode[panel.panelId]) {
         // Auto-select this panel for zoom operation
         if (selectedPanel !== hoveredPanelIndex) {
           setSelectedPanel(hoveredPanelIndex);
@@ -932,12 +938,19 @@ const CanvasCollagePreview = ({
         const clickedPanel = panelRects[clickedPanelIndex];
         const imageIndex = panelImageMapping[clickedPanel.panelId];
         const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
+        
+        // Check if any panel has transform mode enabled
+        const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
+        
         setSelectedPanel(clickedPanelIndex);
         
-        // Check if this panel is in transform mode AND has an image
-        if (hasImage && isTransformMode[clickedPanel.panelId]) {
-          // Only prevent page scrolling when touching a panel with image in transform mode
+        // Prevent page scrolling when touching an image IF any panel has transform mode enabled
+        if (hasImage && anyPanelInTransformMode) {
           e.preventDefault();
+        }
+        
+        // Check if this specific panel is in transform mode for drag interactions
+        if (hasImage && isTransformMode[clickedPanel.panelId]) {
           setIsDragging(true);
           setDragStart({ x, y });
         } else if (onPanelClick) {
@@ -971,15 +984,22 @@ const CanvasCollagePreview = ({
     const rect = canvas.getBoundingClientRect();
     const touches = Array.from(e.touches);
     
+    // Check if any panel has transform mode enabled
+    const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
+    
     if (touches.length === 1 && isDragging && selectedPanel !== null) {
       // Single touch drag
       const panel = panelRects[selectedPanel];
       const imageIndex = panelImageMapping[panel.panelId];
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
-      if (panel && hasImage && isTransformMode[panel.panelId]) {
-        // Only prevent page scrolling when dragging a panel with image in transform mode
+      // Prevent page scrolling when dragging an image IF any panel has transform mode enabled
+      if (hasImage && anyPanelInTransformMode) {
         e.preventDefault();
+      }
+      
+      if (panel && hasImage && isTransformMode[panel.panelId]) {
+        // Only perform actual drag operations on panels in transform mode
         const touch = touches[0];
         const x = touch.clientX - rect.left;
         const y = touch.clientY - rect.top;

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -954,12 +954,8 @@ const CanvasCollagePreview = ({
             onPanelClick(clickedPanel.index, clickedPanel.panelId);
           }
         }
-      } else {
-        // Touched outside any panel - allow normal scrolling
-        if (anyPanelInTransformMode) {
-          // Don't preventDefault to allow page scrolling when touching outside panels
-        }
       }
+      // Note: When touched outside any panel, we allow normal scrolling by not calling preventDefault
     } else if (touches.length === 2 && selectedPanel !== null) {
       // Two touches - prepare for pinch zoom
       const panel = panelRects[selectedPanel];

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -775,14 +775,6 @@ const CanvasCollagePreview = ({
     const canvas = canvasRef.current;
     if (!canvas) return;
     
-    // Check if any panel has transform mode enabled
-    const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
-    
-    // If any panel is in transform mode, prevent page scrolling
-    if (anyPanelInTransformMode) {
-      e.preventDefault();
-    }
-    
     const rect = canvas.getBoundingClientRect();
     const cursorX = e.clientX - rect.left;
     const cursorY = e.clientY - rect.top;
@@ -800,6 +792,8 @@ const CanvasCollagePreview = ({
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
       if (hasImage && isTransformMode[panel.panelId]) {
+        // Only prevent page scrolling when we're actually zooming an image
+        e.preventDefault();
         // Auto-select this panel for zoom operation
         if (selectedPanel !== hoveredPanelIndex) {
           setSelectedPanel(hoveredPanelIndex);
@@ -920,14 +914,6 @@ const CanvasCollagePreview = ({
     const canvas = canvasRef.current;
     if (!canvas) return;
     
-    // Check if any panel has transform mode enabled
-    const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
-    
-    // If any panel is in transform mode, prevent page scrolling when touching the canvas
-    if (anyPanelInTransformMode) {
-      e.preventDefault();
-    }
-    
     const rect = canvas.getBoundingClientRect();
     const touches = Array.from(e.touches);
     
@@ -948,6 +934,8 @@ const CanvasCollagePreview = ({
         
         // Check if this panel is in transform mode
         if (isTransformMode[clickedPanel.panelId]) {
+          // Only prevent page scrolling when touching a panel in transform mode
+          e.preventDefault();
           setIsDragging(true);
           setDragStart({ x, y });
         } else if (onPanelClick) {
@@ -962,6 +950,8 @@ const CanvasCollagePreview = ({
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
       if (panel && hasImage && isTransformMode[panel.panelId]) {
+        // Only prevent page scrolling when performing pinch zoom on a panel in transform mode
+        e.preventDefault();
         const distance = getTouchDistance(touches);
         const currentTransform = panelTransforms[panel.panelId] || { scale: 1, positionX: 0, positionY: 0 };
         
@@ -976,14 +966,6 @@ const CanvasCollagePreview = ({
     const canvas = canvasRef.current;
     if (!canvas) return;
     
-    // Check if any panel has transform mode enabled
-    const anyPanelInTransformMode = Object.values(isTransformMode).some(enabled => enabled);
-    
-    // If any panel is in transform mode, prevent page scrolling during touch moves on canvas
-    if (anyPanelInTransformMode) {
-      e.preventDefault();
-    }
-    
     const rect = canvas.getBoundingClientRect();
     const touches = Array.from(e.touches);
     
@@ -991,6 +973,8 @@ const CanvasCollagePreview = ({
       // Single touch drag
       const panel = panelRects[selectedPanel];
       if (panel && isTransformMode[panel.panelId]) {
+        // Only prevent page scrolling when dragging a panel in transform mode
+        e.preventDefault();
         const touch = touches[0];
         const x = touch.clientX - rect.left;
         const y = touch.clientY - rect.top;
@@ -1065,6 +1049,8 @@ const CanvasCollagePreview = ({
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       
       if (panel && hasImage && isTransformMode[panel.panelId]) {
+        // Only prevent page scrolling when performing pinch zoom on a panel in transform mode
+        e.preventDefault();
         const currentDistance = getTouchDistance(touches);
         const scaleRatio = currentDistance / touchStartDistance;
         const newScale = touchStartScale * scaleRatio;


### PR DESCRIPTION
# Warning

**TL;DR – this PR fixes Mobile but does not fix Desktop**

The description below was written by Cursor based on the initial request. After a couple attempts, it has fixed the issues on Mobile but still has issues on Desktop. I say we go ahead and consider this a fix for Mobile only, and open a separate PR to fix Desktop behavior.

# Original Description


Scrolling behavior in the collage tool was refined to prevent unintended page scrolling during image manipulation.

Previously, page scrolling was globally disabled when any collage panel was in transform mode, affecting both desktop and mobile interactions.

Changes were applied to `src/components/collage/components/CanvasCollagePreview.js`:

*   **Desktop (`handleWheel`):** The `e.preventDefault()` call was moved to occur only when the mouse wheel event is actively zooming an image within a panel that is in transform mode. This ensures page scrolling is only prevented during direct image manipulation.
*   **Mobile (`handleTouchStart`, `handleTouchMove`):** Global `e.preventDefault()` calls were removed. Instead, `e.preventDefault()` is now conditionally applied:
    *   During `handleTouchStart`, only when a touch initiates on a panel in transform mode.
    *   During `handleTouchMove`, only when dragging or pinch-zooming a panel that is in transform mode.

This ensures page scrolling is only prevented when directly interacting with an image in transform mode, allowing normal page scrolling otherwise.