### PR TITLE
Fix result count grammar

### DIFF
--- a/src/pages/V2SearchPage.js
+++ b/src/pages/V2SearchPage.js
@@ -392,7 +392,7 @@ export default function SearchPage() {
       <Typography variant="h3" textAlign="center" mb={2}>
         {newResults && 
           <>
-            Found <b>{newResults.filter(result => !result.isAd).length}</b> results
+            Found <b>{newResults.filter(result => !result.isAd).length}</b> {newResults.filter(result => !result.isAd).length === 1 ? 'result' : 'results'}
           </>
         }
       </Typography>


### PR DESCRIPTION
A change was made in `src/pages/V2SearchPage.js` to correctly display the singular or plural form of "result" based on the search count.

Previously:
*   The result count display always used "results" (e.g., "1 results", "3 results").

Now:
*   A ternary operator was introduced within the `Typography` component on line 394.
*   The expression `newResults.filter(result => !result.isAd).length === 1 ? 'result' : 'results'` now conditionally renders "result" when the count is exactly 1, and "results" for any other count (zero, two, or more).
*   This ensures grammatical correctness for the displayed search result count.