### PR TITLE
Implement collage image swap

### DIFF
--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -1295,7 +1295,8 @@ const CanvasCollagePreview = ({
   const handleTextEdit = useCallback((panelId, event) => {
     // Cancel reorder mode when opening text editor
     if (isReorderMode) {
-      cancelReorderMode();
+      setIsReorderMode(false);
+      setReorderSourcePanel(null);
     }
     
     const isOpening = textEditingPanel !== panelId;
@@ -1441,7 +1442,7 @@ const CanvasCollagePreview = ({
         }
       }, 100); // Small delay to ensure editor is rendered
     }
-  }, [textEditingPanel, panelRects, isReorderMode, cancelReorderMode]);
+  }, [textEditingPanel, panelRects, isReorderMode]);
 
   const handleTextClose = useCallback(() => {
     setTextEditingPanel(null);
@@ -2445,18 +2446,11 @@ const CanvasCollagePreview = ({
     touchStartInfo.current = null;
   }, [handleTextEdit, dismissTransformMode]);
 
-  // Toggle transform mode for a panel
-  const toggleTransformMode = useCallback((panelId) => {
-    // Cancel reorder mode when entering transform mode
-    if (isReorderMode) {
-      cancelReorderMode();
-    }
-    
-    setIsTransformMode(prev => ({
-      ...prev,
-      [panelId]: !prev[panelId]
-    }));
-  }, [isReorderMode, cancelReorderMode]);
+  // Cancel reorder mode
+  const cancelReorderMode = useCallback(() => {
+    setIsReorderMode(false);
+    setReorderSourcePanel(null);
+  }, []);
 
   // Start reorder mode for a panel
   const startReorderMode = useCallback((panelId) => {
@@ -2468,11 +2462,19 @@ const CanvasCollagePreview = ({
     setReorderSourcePanel(panelId);
   }, []);
 
-  // Cancel reorder mode
-  const cancelReorderMode = useCallback(() => {
-    setIsReorderMode(false);
-    setReorderSourcePanel(null);
-  }, []);
+  // Toggle transform mode for a panel
+  const toggleTransformMode = useCallback((panelId) => {
+    // Cancel reorder mode when entering transform mode
+    if (isReorderMode) {
+      setIsReorderMode(false);
+      setReorderSourcePanel(null);
+    }
+    
+    setIsTransformMode(prev => ({
+      ...prev,
+      [panelId]: !prev[panelId]
+    }));
+  }, [isReorderMode]);
 
   // Handle destination selection during reorder
   const handleReorderDestination = useCallback((destinationPanelId) => {
@@ -2498,8 +2500,9 @@ const CanvasCollagePreview = ({
     }
 
     updatePanelImageMapping(newMapping);
-    cancelReorderMode();
-  }, [reorderSourcePanel, panelImageMapping, updatePanelImageMapping, cancelReorderMode]);
+    setIsReorderMode(false);
+    setReorderSourcePanel(null);
+  }, [reorderSourcePanel, panelImageMapping, updatePanelImageMapping]);
 
   // Get final canvas for export
   const getCanvasBlob = useCallback(() => {

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -407,6 +407,7 @@ const CanvasCollagePreview = ({
   onMenuOpen,
   aspectRatioValue = 1,
   panelImageMapping = {},
+  updatePanelImageMapping,
   borderThickness = 0,
   borderColor = '#000000',
   panelTransforms = {},
@@ -2459,6 +2460,10 @@ const CanvasCollagePreview = ({
 
   // Start reorder mode for a panel
   const startReorderMode = useCallback((panelId) => {
+    if (!panelId) {
+      console.warn('Invalid panel ID for reorder mode:', panelId);
+      return;
+    }
     setIsReorderMode(true);
     setReorderSourcePanel(panelId);
   }, []);
@@ -2471,7 +2476,8 @@ const CanvasCollagePreview = ({
 
   // Handle destination selection during reorder
   const handleReorderDestination = useCallback((destinationPanelId) => {
-    if (!reorderSourcePanel || !panelImageMapping || !updatePanelImageMapping) {
+    if (!reorderSourcePanel || !panelImageMapping || !updatePanelImageMapping || !destinationPanelId) {
+      console.warn('Invalid reorder destination selection:', { reorderSourcePanel, panelImageMapping: !!panelImageMapping, updatePanelImageMapping: !!updatePanelImageMapping, destinationPanelId });
       return;
     }
 
@@ -2485,12 +2491,10 @@ const CanvasCollagePreview = ({
       // Swap images between source and destination
       newMapping[reorderSourcePanel] = destinationImageIndex;
       newMapping[destinationPanelId] = sourceImageIndex;
-    } else {
+    } else if (sourceImageIndex !== undefined) {
       // Move image from source to destination (destination was empty)
-      if (sourceImageIndex !== undefined) {
-        newMapping[destinationPanelId] = sourceImageIndex;
-        delete newMapping[reorderSourcePanel];
-      }
+      newMapping[destinationPanelId] = sourceImageIndex;
+      delete newMapping[reorderSourcePanel];
     }
 
     updatePanelImageMapping(newMapping);
@@ -2873,7 +2877,7 @@ const CanvasCollagePreview = ({
           }}
         >
           <Typography variant="body2" sx={{ fontSize: '14px', fontWeight: 'bold' }}>
-            Click a frame to move "{reorderSourcePanel}" here, or click outside to cancel
+            Click a frame to move image here, or click outside to cancel
           </Typography>
         </Box>
       )}

--- a/src/components/collage/components/CollagePreview.js
+++ b/src/components/collage/components/CollagePreview.js
@@ -224,6 +224,7 @@ const CollagePreview = ({
         onMenuOpen={handleMenuOpen}
         aspectRatioValue={aspectRatioValue}
         panelImageMapping={panelImageMapping}
+        updatePanelImageMapping={updatePanelImageMapping}
         borderThickness={borderThickness}
         borderColor={borderColor}
         panelTransforms={panelTransforms}


### PR DESCRIPTION
Adds image reordering functionality to the collage preview for swapping image locations.

The initial implementation caused crashes due to a missing prop (`updatePanelImageMapping`) and, more critically, circular dependencies within `useCallback` hooks (e.g., `toggleTransformMode` referencing `cancelReorderMode` before its definition). These dependencies were resolved by reordering function definitions and inlining state updates to break the circularity, ensuring variables are initialized before access.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-cc6f432c-be03-4462-aae9-347c2cae63cd) · [Cursor](https://cursor.com/background-agent?bcId=bc-cc6f432c-be03-4462-aae9-347c2cae63cd)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)