### PR TITLE
Fix ESLint warnings in selected utility files

### DIFF
--- a/src/utils/fetchShows.js
+++ b/src/utils/fetchShows.js
@@ -73,7 +73,7 @@ async function fetchShowsFromAPI() {
 }
 
 async function fetchFavorites() {
-  const currentUser = await Auth.currentAuthenticatedUser();
+  await Auth.currentAuthenticatedUser();
 
   let nextToken = null;
   let allFavorites = [];
@@ -86,8 +86,9 @@ async function fetchFavorites() {
       nextToken,
     }));
 
-    allFavorites = allFavorites.concat(result.data.listFavorites.items);
-    nextToken = result.data.listFavorites.nextToken;
+    const { items, nextToken: newNextToken } = result.data.listFavorites;
+    allFavorites = allFavorites.concat(items);
+    nextToken = newNextToken;
 
   } while (nextToken);
 
@@ -96,7 +97,7 @@ async function fetchFavorites() {
 
 async function updateCacheAndReturnData(data, cacheKey) {
   try {
-    const currentUser = await Auth.currentAuthenticatedUser();
+    await Auth.currentAuthenticatedUser();
     const favorites = await fetchFavorites();
     const favoriteShowIds = new Set(favorites.map(favorite => favorite.cid));
 

--- a/src/utils/fetchShowsRevised.js
+++ b/src/utils/fetchShowsRevised.js
@@ -1,5 +1,4 @@
-import { API, graphqlOperation, Auth } from 'aws-amplify';
-import { listFavorites } from '../graphql/queries';
+import { API, Auth } from 'aws-amplify';
 
 const listAliasesQuery = /* GraphQL */ `
   query ListAliases(
@@ -58,25 +57,6 @@ async function fetchShows() {
     return sortedMetadata;
 }
 
-async function fetchFavorites() {
-    let nextToken = null;
-    let allFavorites = [];
-
-    do {
-        // Disable ESLint check for await-in-loop
-        // eslint-disable-next-line no-await-in-loop
-        const result = await API.graphql(graphqlOperation(listFavorites, {
-            limit: 10,
-            nextToken,
-        }));
-
-        allFavorites = allFavorites.concat(result.data.listFavorites.items);
-        nextToken = result.data.listFavorites.nextToken;
-
-    } while (nextToken);
-
-    return allFavorites;
-}
 
 async function getShowsWithFavorites(favorites = []) {
     const shows = await fetchShows();

--- a/src/utils/frameHandlerV2.js
+++ b/src/utils/frameHandlerV2.js
@@ -3,25 +3,6 @@ import { Storage } from "aws-amplify";
 import sanitizeHtml from 'sanitize-html';
 import { extractVideoFrames } from './videoFrameExtractor';
 
-// Utility function to fetch JSON data from a given URL
-const fetchJSON = async (url) => {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-  return response.json();
-};
-
-// Utility function to fetch CSV data and parse it
-const fetchCSV = async (url) => {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-  const csvText = await response.text();
-  return csvText.split('\n').map((row) => row.split(','));
-};
-
 // Helper function to find subtitle info for a frame and decode base64 subtitle
 const findSubtitleForFrame = (csvData, season, episode, frame) => {
   // console.log('finding subtitle for ', season, episode, frame);

--- a/src/utils/videoFrameExtractor.js
+++ b/src/utils/videoFrameExtractor.js
@@ -6,7 +6,7 @@ export async function extractVideoFrames(cid, season, episode, frameIndexes) {
   return frameUrls;
 }
 
-export async function extractFramesFromVideo(_videoUrl, _frameNumbers, _assumedFps = 10, _scaleFactor = 1.0) {
+export async function extractFramesFromVideo() {
   console.warn('extractFramesFromVideo is deprecated. Please use extractVideoFrames instead.');
   return [];
 }


### PR DESCRIPTION
## Summary
- silence unused variable warnings in fetchShows.js
- drop unused fetchFavorites helper
- remove unused helpers in frameHandlerV2
- clean up unused parameters in videoFrameExtractor

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883e3334df8832d9d8629a76eb0059f