### PR TITLE
Fix ESLint warnings in utilities

### DIFF
--- a/src/utils/fetchShows.js
+++ b/src/utils/fetchShows.js
@@ -1,14 +1,10 @@
 // fetchShows.js
 
-import { API, graphqlOperation, Auth } from "aws-amplify";
+import { API, graphqlOperation, Auth } from 'aws-amplify';
 import { listFavorites } from '../graphql/queries';
 
 const listAliasesQuery = /* GraphQL */ `
-  query ListAliases(
-    $filter: ModelAliasFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
+  query ListAliases($filter: ModelAliasFilterInput, $limit: Int, $nextToken: String) {
     listAliases(filter: $filter, limit: $limit, nextToken: $nextToken) {
       items {
         id
@@ -55,12 +51,12 @@ async function fetchShowsFromAPI() {
     authMode: 'API_KEY',
   });
 
-  const loadedV2Shows = aliases?.data?.listAliases?.items.filter(obj => obj?.v2ContentMetadata) || [];
+  const loadedV2Shows = aliases?.data?.listAliases?.items.filter((obj) => obj?.v2ContentMetadata) || [];
 
-  const finalShows = loadedV2Shows.map(v2Show => ({
+  const finalShows = loadedV2Shows.map((v2Show) => ({
     ...v2Show.v2ContentMetadata,
     id: v2Show.id,
-    cid: v2Show.v2ContentMetadata.id
+    cid: v2Show.v2ContentMetadata.id,
   }));
 
   const sortedMetadata = finalShows.sort((a, b) => {
@@ -73,7 +69,7 @@ async function fetchShowsFromAPI() {
 }
 
 async function fetchFavorites() {
-  const currentUser = await Auth.currentAuthenticatedUser();
+  await Auth.currentAuthenticatedUser();
 
   let nextToken = null;
   let allFavorites = [];
@@ -81,14 +77,16 @@ async function fetchFavorites() {
   do {
     // Disable ESLint check for await-in-loop
     // eslint-disable-next-line no-await-in-loop
-    const result = await API.graphql(graphqlOperation(listFavorites, {
-      limit: 10,
-      nextToken,
-    }));
+    const result = await API.graphql(
+      graphqlOperation(listFavorites, {
+        limit: 10,
+        nextToken,
+      })
+    );
 
-    allFavorites = allFavorites.concat(result.data.listFavorites.items);
-    nextToken = result.data.listFavorites.nextToken;
-
+    const { items, nextToken: newNextToken } = result.data.listFavorites;
+    allFavorites = allFavorites.concat(items);
+    nextToken = newNextToken;
   } while (nextToken);
 
   return allFavorites;
@@ -96,13 +94,13 @@ async function fetchFavorites() {
 
 async function updateCacheAndReturnData(data, cacheKey) {
   try {
-    const currentUser = await Auth.currentAuthenticatedUser();
+    await Auth.currentAuthenticatedUser();
     const favorites = await fetchFavorites();
-    const favoriteShowIds = new Set(favorites.map(favorite => favorite.cid));
+    const favoriteShowIds = new Set(favorites.map((favorite) => favorite.cid));
 
-    data = data.map(show => ({
+    data = data.map((show) => ({
       ...show,
-      isFavorite: favoriteShowIds.has(show.id)
+      isFavorite: favoriteShowIds.has(show.id),
     }));
   } catch (error) {
     // If there's an error fetching favorites (likely due to not being authenticated), return data without favorites.

--- a/src/utils/fetchShowsRevised.js
+++ b/src/utils/fetchShowsRevised.js
@@ -2,11 +2,7 @@ import { API, graphqlOperation, Auth } from 'aws-amplify';
 import { listFavorites } from '../graphql/queries';
 
 const listAliasesQuery = /* GraphQL */ `
-  query ListAliases(
-    $filter: ModelAliasFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
+  query ListAliases($filter: ModelAliasFilterInput, $limit: Int, $nextToken: String) {
     listAliases(filter: $filter, limit: $limit, nextToken: $nextToken) {
       items {
         id
@@ -35,67 +31,69 @@ const listAliasesQuery = /* GraphQL */ `
 `;
 
 async function fetchShows() {
-    const aliases = await API.graphql({
-        query: listAliasesQuery,
-        variables: { filter: {}, limit: 250 },
-        authMode: 'API_KEY',
-    });
+  const aliases = await API.graphql({
+    query: listAliasesQuery,
+    variables: { filter: {}, limit: 250 },
+    authMode: 'API_KEY',
+  });
 
-    const loadedV2Shows = aliases?.data?.listAliases?.items.filter(obj => obj?.v2ContentMetadata) || [];
+  const loadedV2Shows = aliases?.data?.listAliases?.items.filter((obj) => obj?.v2ContentMetadata) || [];
 
-    const finalShows = loadedV2Shows.map(v2Show => ({
-        ...v2Show.v2ContentMetadata,
-        id: v2Show.id,
-        cid: v2Show.v2ContentMetadata.id
-    }));
+  const finalShows = loadedV2Shows.map((v2Show) => ({
+    ...v2Show.v2ContentMetadata,
+    id: v2Show.id,
+    cid: v2Show.v2ContentMetadata.id,
+  }));
 
-    const sortedMetadata = finalShows.sort((a, b) => {
-        const titleA = a.title.toLowerCase().replace(/^the\s+/, '');
-        const titleB = b.title.toLowerCase().replace(/^the\s+/, '');
-        return titleA.localeCompare(titleB);
-    });
+  const sortedMetadata = finalShows.sort((a, b) => {
+    const titleA = a.title.toLowerCase().replace(/^the\s+/, '');
+    const titleB = b.title.toLowerCase().replace(/^the\s+/, '');
+    return titleA.localeCompare(titleB);
+  });
 
-    return sortedMetadata;
+  return sortedMetadata;
 }
 
 async function fetchFavorites() {
-    let nextToken = null;
-    let allFavorites = [];
+  let nextToken = null;
+  let allFavorites = [];
 
-    do {
-        // Disable ESLint check for await-in-loop
-        // eslint-disable-next-line no-await-in-loop
-        const result = await API.graphql(graphqlOperation(listFavorites, {
-            limit: 10,
-            nextToken,
-        }));
+  do {
+    // Disable ESLint check for await-in-loop
+    // eslint-disable-next-line no-await-in-loop
+    const result = await API.graphql(
+      graphqlOperation(listFavorites, {
+        limit: 10,
+        nextToken,
+      })
+    );
 
-        allFavorites = allFavorites.concat(result.data.listFavorites.items);
-        nextToken = result.data.listFavorites.nextToken;
+    const { items, nextToken: newNextToken } = result.data.listFavorites;
+    allFavorites = allFavorites.concat(items);
+    nextToken = newNextToken;
+  } while (nextToken);
 
-    } while (nextToken);
-
-    return allFavorites;
+  return allFavorites;
 }
 
 async function getShowsWithFavorites(favorites = []) {
-    const shows = await fetchShows();
-    
-    try {
-        await Auth.currentAuthenticatedUser();
-        // const favorites = await fetchFavorites();
-        // const favoriteShowIds = new Set(favorites.map(favorite => favorite.cid));
+  const shows = await fetchShows();
 
-        const showsWithFavorites = shows.map(show => ({
-            ...show,
-            isFavorite: favorites.includes(show.id)
-        }));
+  try {
+    await Auth.currentAuthenticatedUser();
+    // const favorites = await fetchFavorites();
+    // const favoriteShowIds = new Set(favorites.map(favorite => favorite.cid));
 
-        return showsWithFavorites;
-    } catch (error) {
-        // If there's an error fetching favorites (likely due to not being authenticated), return shows without favorites.
-        return shows;
-    }
+    const showsWithFavorites = shows.map((show) => ({
+      ...show,
+      isFavorite: favorites.includes(show.id),
+    }));
+
+    return showsWithFavorites;
+  } catch (error) {
+    // If there's an error fetching favorites (likely due to not being authenticated), return shows without favorites.
+    return shows;
+  }
 }
 
-export { getShowsWithFavorites };
+export { getShowsWithFavorites, fetchFavorites };

--- a/src/utils/videoFrameExtractor.js
+++ b/src/utils/videoFrameExtractor.js
@@ -1,12 +1,13 @@
 export async function extractVideoFrames(cid, season, episode, frameIndexes) {
   const frameUrls = frameIndexes.map(
-    (frameId) => `https://v2-${process.env.REACT_APP_USER_BRANCH}.memesrc.com/frame/${cid}/${season}/${episode}/${frameId}`
+    (frameId) =>
+      `https://v2-${process.env.REACT_APP_USER_BRANCH}.memesrc.com/frame/${cid}/${season}/${episode}/${frameId}`
   );
 
   return frameUrls;
 }
 
-export async function extractFramesFromVideo(_videoUrl, _frameNumbers, _assumedFps = 10, _scaleFactor = 1.0) {
+export async function extractFramesFromVideo() {
   console.warn('extractFramesFromVideo is deprecated. Please use extractVideoFrames instead.');
   return [];
 }


### PR DESCRIPTION
## Summary
- resolve ESLint warnings for fetchShows.js
- resolve ESLint warnings for fetchShowsRevised.js
- clean unused helpers from frameHandlerV2.js
- simplify deprecated function in videoFrameExtractor.js

## Testing
- `npm run lint`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6883e3310f58832db2086c67e9b2eb30