### PR TITLE
Resolve lint warnings in fetch utilities

### DIFF
--- a/src/utils/fetchShowsRevised.js
+++ b/src/utils/fetchShowsRevised.js
@@ -1,12 +1,7 @@
-import { API, graphqlOperation, Auth } from 'aws-amplify';
-import { listFavorites } from '../graphql/queries';
+import { API, Auth } from 'aws-amplify';
 
 const listAliasesQuery = /* GraphQL */ `
-  query ListAliases(
-    $filter: ModelAliasFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
+  query ListAliases($filter: ModelAliasFilterInput, $limit: Int, $nextToken: String) {
     listAliases(filter: $filter, limit: $limit, nextToken: $nextToken) {
       items {
         id
@@ -35,67 +30,47 @@ const listAliasesQuery = /* GraphQL */ `
 `;
 
 async function fetchShows() {
-    const aliases = await API.graphql({
-        query: listAliasesQuery,
-        variables: { filter: {}, limit: 250 },
-        authMode: 'API_KEY',
-    });
+  const aliases = await API.graphql({
+    query: listAliasesQuery,
+    variables: { filter: {}, limit: 250 },
+    authMode: 'API_KEY',
+  });
 
-    const loadedV2Shows = aliases?.data?.listAliases?.items.filter(obj => obj?.v2ContentMetadata) || [];
+  const loadedV2Shows = aliases?.data?.listAliases?.items.filter((obj) => obj?.v2ContentMetadata) || [];
 
-    const finalShows = loadedV2Shows.map(v2Show => ({
-        ...v2Show.v2ContentMetadata,
-        id: v2Show.id,
-        cid: v2Show.v2ContentMetadata.id
-    }));
+  const finalShows = loadedV2Shows.map((v2Show) => ({
+    ...v2Show.v2ContentMetadata,
+    id: v2Show.id,
+    cid: v2Show.v2ContentMetadata.id,
+  }));
 
-    const sortedMetadata = finalShows.sort((a, b) => {
-        const titleA = a.title.toLowerCase().replace(/^the\s+/, '');
-        const titleB = b.title.toLowerCase().replace(/^the\s+/, '');
-        return titleA.localeCompare(titleB);
-    });
+  const sortedMetadata = finalShows.sort((a, b) => {
+    const titleA = a.title.toLowerCase().replace(/^the\s+/, '');
+    const titleB = b.title.toLowerCase().replace(/^the\s+/, '');
+    return titleA.localeCompare(titleB);
+  });
 
-    return sortedMetadata;
-}
-
-async function fetchFavorites() {
-    let nextToken = null;
-    let allFavorites = [];
-
-    do {
-        // Disable ESLint check for await-in-loop
-        // eslint-disable-next-line no-await-in-loop
-        const result = await API.graphql(graphqlOperation(listFavorites, {
-            limit: 10,
-            nextToken,
-        }));
-
-        allFavorites = allFavorites.concat(result.data.listFavorites.items);
-        nextToken = result.data.listFavorites.nextToken;
-
-    } while (nextToken);
-
-    return allFavorites;
+  return sortedMetadata;
 }
 
 async function getShowsWithFavorites(favorites = []) {
-    const shows = await fetchShows();
-    
-    try {
-        await Auth.currentAuthenticatedUser();
-        // const favorites = await fetchFavorites();
-        // const favoriteShowIds = new Set(favorites.map(favorite => favorite.cid));
+  const shows = await fetchShows();
 
-        const showsWithFavorites = shows.map(show => ({
-            ...show,
-            isFavorite: favorites.includes(show.id)
-        }));
+  try {
+    await Auth.currentAuthenticatedUser();
+    // const favorites = await fetchFavorites();
+    // const favoriteShowIds = new Set(favorites.map(favorite => favorite.cid));
 
-        return showsWithFavorites;
-    } catch (error) {
-        // If there's an error fetching favorites (likely due to not being authenticated), return shows without favorites.
-        return shows;
-    }
+    const showsWithFavorites = shows.map((show) => ({
+      ...show,
+      isFavorite: favorites.includes(show.id),
+    }));
+
+    return showsWithFavorites;
+  } catch (error) {
+    // If there's an error fetching favorites (likely due to not being authenticated), return shows without favorites.
+    return shows;
+  }
 }
 
 export { getShowsWithFavorites };


### PR DESCRIPTION
## Summary
- clean up unused variables and object destruction in `fetchShows.js`
- remove unused fetchFavorites helper and unused imports in `fetchShowsRevised.js`

## Testing
- `npm run lint`
- `npm test -- -u`


------
https://chatgpt.com/codex/tasks/task_e_6883e32abe24832db0da01785dae7d4c