### PR TITLE
Fix ESLint warnings

### DIFF
--- a/src/components/nav-section/CollageNavTeaser.js
+++ b/src/components/nav-section/CollageNavTeaser.js
@@ -4,12 +4,11 @@ import {
   Box,
   Typography,
   Chip,
-  useMediaQuery,
   ListItemButton,
   ListItemIcon,
   ListItemText,
 } from '@mui/material';
-import { useTheme, styled } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import ScienceIcon from '@mui/icons-material/Science';
 import PhotoLibraryIcon from '@mui/icons-material/PhotoLibrary';
 import DashboardIcon from '@mui/icons-material/Dashboard';
@@ -101,7 +100,6 @@ const StyledTeaserNavItemIcon = styled(ListItemIcon)({
 });
 
 export default function CollageNavTeaser() {
-  const theme = useTheme();
   const location = useLocation();
   const { user } = useContext(UserContext);
   const isActive = location.pathname === '/collage';

--- a/src/contexts/SubscribeDialog.js
+++ b/src/contexts/SubscribeDialog.js
@@ -1,7 +1,8 @@
-import { AutoFixHighRounded, Block, Close, Favorite, Star, SupportAgent, ExpandMore, Clear, Check, Bolt, Share, ThumbUp, Feedback, ArrowBack, Settings } from '@mui/icons-material';
-import { Box, Button, Card, Checkbox, Chip, CircularProgress, Collapse, Dialog, DialogContent, DialogTitle, Divider, Fade, Grid, IconButton, LinearProgress, Typography, useMediaQuery, FormControlLabel, Fab, Stack } from '@mui/material';
+import { AutoFixHighRounded, Close, SupportAgent, Check, Bolt, Share, ThumbUp, Feedback, ArrowBack } from '@mui/icons-material';
+import { Box, Button, Card, Chip, CircularProgress, Collapse, Dialog, DialogContent, DialogTitle, Divider, Fade, Grid, IconButton, Typography, useMediaQuery, Stack } from '@mui/material';
 import { API, graphqlOperation } from 'aws-amplify';
 import { createContext, useState, useRef, useEffect, useContext } from 'react';
+import PropTypes from 'prop-types';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { LoadingButton } from '@mui/lab';
 import { UserContext } from '../UserContext';
@@ -35,20 +36,16 @@ export const DialogProvider = ({ children }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const isXs = useMediaQuery(theme => theme.breakpoints.down('sm'));
-  const isMd = useMediaQuery(theme => theme.breakpoints.up('sm'));
   const isCompact = useMediaQuery('(max-width:850px)');
   const [subscriptionDialogOpen, setSubscriptionDialogOpen] = useState(false);
   const [selectedPlan, setSelectedPlan] = useState(getInitialPlan());
   const [loading, setLoading] = useState(false);
   const { user } = useContext(UserContext);
   const [checkoutLink, setCheckoutLink] = useState();
-  const [billingAgreement, setBillingAgreement] = useState(false);
-
-  const [askedAboutCredits, setAskedAboutCredits] = useState(false);
 
   const [selectedTitleSubtitle, setSelectedTitleSubtitle] = useState(null);
 
-  const { countryCode, countryName } = useUserLocation();
+  const { countryCode } = useUserLocation();
 
   const [creditOptionsExpanded, setCreditOptionsExpanded] = useState(!isCompact);
 
@@ -83,22 +80,16 @@ export const DialogProvider = ({ children }) => {
 
   const setSelectedPlanAndScroll = (plan) => {
     setSelectedPlan(plan);
-    setAskedAboutCredits(false);
     if (isCompact) {
       setCreditOptionsExpanded(false);
     }
     subscribeButtonRef.current.scrollIntoView({ behavior: 'smooth' });
   };
 
-  const openDialog = (content) => {
-    setSubscriptionDialogOpen(true);
-  };
-
   const closeDialog = () => {
     setSubscriptionDialogOpen(false);
     setLoading(false)
     setCheckoutLink()
-    setBillingAgreement(false)
   };
 
   const buySubscription = () => {
@@ -190,10 +181,6 @@ export const DialogProvider = ({ children }) => {
     }
   };
 
-  const getRandomTitleSubtitle = () => {
-    const randomIndex = Math.floor(Math.random() * titleSubtitlePairs.length);
-    return titleSubtitlePairs[randomIndex];
-  };
 
   const openSubscriptionDialog = () => {
     setSubscriptionDialogOpen(true)
@@ -986,4 +973,8 @@ export const DialogProvider = ({ children }) => {
       </Dialog>
     </SubscribeDialogContext.Provider>
   );
+};
+
+DialogProvider.propTypes = {
+  children: PropTypes.node
 };

--- a/src/layouts/dashboard/nav/index.js
+++ b/src/layouts/dashboard/nav/index.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import { useEffect, useContext } from 'react';
+import { useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 // @mui
 import { styled, alpha } from '@mui/material/styles';
-import { Box, Link, Button, Drawer, Typography, Avatar, Stack, Chip, Divider } from '@mui/material';
+import { Box, Link, Drawer, Typography, Stack, Chip, Divider } from '@mui/material';
 // components
 import Logo from '../../../components/logo';
 import Scrollbar from '../../../components/scrollbar';
@@ -29,7 +29,7 @@ Nav.propTypes = {
 };
 
 export default function Nav({ openNav, onCloseNav }) {
-  const { pathname } = useLocation();
+  useLocation();
   const navigate = useNavigate();
   const userDetails = useContext(UserContext)
 

--- a/src/pages/DashboardAliasPageRevised.js
+++ b/src/pages/DashboardAliasPageRevised.js
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import { Container, Divider, IconButton, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography, Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, CircularProgress } from "@mui/material";
 import { API, Storage, graphqlOperation } from 'aws-amplify';
 import { Add, Edit, Delete, Refresh } from "@mui/icons-material";
@@ -73,6 +74,13 @@ const AliasFormDialog = ({ open, onClose, onSubmit, initialValues }) => {
   );
 };
 
+AliasFormDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  initialValues: PropTypes.object.isRequired,
+};
+
 
 const ConfirmDeleteDialog = ({ open, onClose, onConfirm }) => (
     <Dialog open={open} onClose={onClose}>
@@ -87,11 +95,17 @@ const ConfirmDeleteDialog = ({ open, onClose, onConfirm }) => (
     </Dialog>
   );
 
+ConfirmDeleteDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+};
+
 /* Main Component */
 
 const AliasManagementPageRevised = () => {
   const [aliases, setAliases] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [currentAlias, setCurrentAlias] = useState(null);

--- a/src/pages/EditorProjectsPage.js
+++ b/src/pages/EditorProjectsPage.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Container, Typography, ImageList, ImageListItem, Button } from '@mui/material';
+import { Container, ImageList, ImageListItem, Button } from '@mui/material';
 import { Add } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { API, Storage, graphqlOperation } from 'aws-amplify';

--- a/src/pages/FacebookAuthDemo.js
+++ b/src/pages/FacebookAuthDemo.js
@@ -61,7 +61,7 @@ export default function FacebookAuthDemo() {
         facebookAccessToken: response.authResponse.accessToken,
         facebookUserId: response.authResponse.userID,
       });
-      fetchProfileInfo(response.authResponse.accessToken);
+      fetchProfileInfo();
       fetchGroupPosts(response.authResponse.userID, response.authResponse.accessToken);
     } else {
       // User is not logged into Facebook or your app
@@ -88,7 +88,7 @@ export default function FacebookAuthDemo() {
     }, loginOptions);
   };
 
-  const fetchProfileInfo = (accessToken) => {
+  const fetchProfileInfo = () => {
     window.FB.api('/me', { fields: 'id,name,first_name,last_name,picture.type(large)' }, (response) => {
       if (response && !response.error) {
         setProfileInfo(response);

--- a/src/sections/auth/login/ForgotPasswordForm.js
+++ b/src/sections/auth/login/ForgotPasswordForm.js
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Backdrop, CircularProgress, Link, Stack, TextField, Typography, styled } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
-import { API, Auth } from 'aws-amplify';
+import { Auth } from 'aws-amplify';
 import { useContext, useState } from 'react';
 import { UserContext } from '../../../UserContext';
 import { SnackbarContext } from '../../../SnackbarContext';
@@ -16,15 +16,15 @@ input:-webkit-autofill:active  {
     background-clip: content-box !important;
 `;
 
-export default function ResetPasswordForm(props) {
+export default function ResetPasswordForm() {
   const navigate = useNavigate();
-  const { user, setUser } = useContext(UserContext);
+  useContext(UserContext);
   const { setSeverity, setMessage, setOpen } = useContext(SnackbarContext);
   const [username, setUsername] = useState('');
   const [code, setCode] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
-  const [backdropOpen, setBackdropOpen] = useState(false);
+  const [backdropOpen] = useState(false);
   const [resetSent, setResetSent] = useState(false);
 
   const handleResetPassword = () => {

--- a/src/sections/server/ServerInfo.js
+++ b/src/sections/server/ServerInfo.js
@@ -1,13 +1,12 @@
 // ServerInfo.js
 
 import React, { useEffect, useState } from 'react';
-import { Alert, Button, Card, Container, Dialog, DialogActions, DialogContent, DialogTitle, Divider, Grid, Stack, Typography, useMediaQuery } from '@mui/material';
+import { Alert, Card, Container, Divider, Grid, Stack, Typography, useMediaQuery } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
-import PropTypes from 'prop-types';
 import NetworkGraph from './NetworkGraph';
 import IndexTable from './IndexTable';
 
-export default function ServerInfo({ details }) {
+export default function ServerInfo() {
     const isSm = useMediaQuery(theme => theme.breakpoints.up('sm'));
     const isLg = useMediaQuery(theme => theme.breakpoints.up('lg'));
     const [connected, setConnected] = useState(false);
@@ -128,6 +127,3 @@ export default function ServerInfo({ details }) {
     );
 }
 
-ServerInfo.propTypes = {
-    details: PropTypes.object,
-};


### PR DESCRIPTION
## Summary
- clean up unused imports and variables across dashboard and server components
- add missing PropTypes
- simplify Facebook auth demo helper
- tidy editor pages and forms

## Testing
- `npx eslint src/pages/EditorPage.js src/contexts/SubscribeDialog.js src/pages/DashboardAliasPageRevised.js src/sections/server/ServerInfo.js src/sections/auth/login/ForgotPasswordForm.js src/layouts/dashboard/nav/index.js src/components/nav-section/CollageNavTeaser.js src/pages/FacebookAuthDemo.js src/pages/EditorProjectsPage.js`
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883efd27e7c832d80a0a575dcb73f66