### PR TITLE
Fix unused variable lint warnings

### DIFF
--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
-import { Box, IconButton, Typography, useMediaQuery, Menu, MenuItem, ListItemIcon } from "@mui/material";
+import { Box, IconButton, Typography, Menu, MenuItem, ListItemIcon } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { OpenWith, Check, Place, Crop, DragIndicator } from '@mui/icons-material';
 import { layoutDefinitions } from '../config/layouts';
@@ -400,11 +400,9 @@ const parseGridToRects = (layoutConfig, containerWidth, containerHeight, panelCo
  */
 const CanvasCollagePreview = ({
   selectedTemplate,
-  selectedAspectRatio,
   panelCount,
   images = [],
   onPanelClick,
-  onMenuOpen,
   aspectRatioValue = 1,
   panelImageMapping = {},
   updatePanelImageMapping,
@@ -451,9 +449,6 @@ const CanvasCollagePreview = ({
   const [borderDragStart, setBorderDragStart] = useState({ x: 0, y: 0 });
   const [hoveredBorder, setHoveredBorder] = useState(null);
   const [customLayoutConfig, setCustomLayoutConfig] = useState(null);
-
-  // Mobile detection for slider fix
-  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('md'));
 
   // Base canvas size for text scaling calculations
   const BASE_CANVAS_WIDTH = 400;
@@ -756,13 +751,10 @@ const CanvasCollagePreview = ({
     
     // Draw panels
     panelRects.forEach((rect) => {
-      const { x, y, width, height, panelId, index } = rect;
+      const { x, y, width, height, panelId } = rect;
       const imageIndex = panelImageMapping[panelId];
       const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
       const transform = panelTransforms[panelId] || { scale: 1, positionX: 0, positionY: 0 };
-      const isHovered = hoveredPanel === index;
-      const isSelected = selectedPanel === index;
-      const isInTransformMode = isTransformMode[panelId];
       const panelText = panelTexts[panelId] || {};
       
       // Draw panel background
@@ -1298,7 +1290,7 @@ const CanvasCollagePreview = ({
   }, [lastUsedTextSettings, textScaleFactor]);
 
   // Handle text editing
-  const handleTextEdit = useCallback((panelId, event) => {
+  const handleTextEdit = useCallback((panelId) => {
     // Cancel reorder mode when opening text editor
     if (isReorderMode) {
       setIsReorderMode(false);
@@ -1686,10 +1678,6 @@ const CanvasCollagePreview = ({
           // Calculate proposed new positions
           const newPositionX = currentTransform.positionX + deltaX;
           const newPositionY = currentTransform.positionY + deltaY;
-          
-          // Calculate the final image bounds with new position
-          const finalOffsetX = centerOffsetX + newPositionX;
-          const finalOffsetY = centerOffsetY + newPositionY;
           
           // Calculate bounds to prevent white space (image must always cover the panel)
           let minPositionX;
@@ -2566,9 +2554,6 @@ const CanvasCollagePreview = ({
   const getCanvasBlob = useCallback(() => new Promise((resolve) => {
       const canvas = canvasRef.current;
       if (canvas) {
-        // Temporarily set the generating flag to exclude placeholder text
-        const originalGenerating = isGeneratingCollage;
-        
         // Create a temporary canvas for export without placeholder text
         const exportCanvas = document.createElement('canvas');
         const exportCtx = exportCanvas.getContext('2d');
@@ -2940,31 +2925,12 @@ const CanvasCollagePreview = ({
       
       {/* Control panels positioned over canvas */}
       {panelRects.map((rect) => {
-        const { panelId, index } = rect;
+        const { panelId } = rect;
         const imageIndex = panelImageMapping[panelId];
         const hasImage = imageIndex !== undefined && loadedImages[imageIndex];
         const isInTransformMode = isTransformMode[panelId];
         
         // Calculate responsive dimensions based on panel size with mobile-friendly minimums
-        const minPanelSize = Math.min(rect.width, rect.height);
-        const isMobileSize = minPanelSize < 200; // Detect mobile-sized panels
-        
-        // Use larger minimums for mobile touch targets
-        const collapsedHeight = Math.max(isMobileSize ? 28 : 24, Math.min(40, minPanelSize * 0.15));
-        const sidePadding = Math.max(isMobileSize ? 6 : 4, Math.min(12, rect.width * 0.02));
-        const tabSize = Math.max(isMobileSize ? 28 : 22, Math.min(32, minPanelSize * 0.12)); // Slightly smaller but still touch-friendly
-        const fontSize = Math.max(isMobileSize ? 11 : 10, Math.min(14, minPanelSize * 0.08));
-        const borderRadius = Math.max(3, Math.min(8, minPanelSize * 0.02));
-        
-        // Calculate dynamic expanded height based on content needs
-        const tabRowHeight = tabSize + (isMobileSize ? 12 : 8); // Tab height + margin
-        const contentAreaHeight = isMobileSize ? 80 : 65; // More space for content (text field, sliders, etc.)
-        const containerPadding = (isMobileSize ? 12 : 8); // Top/bottom padding
-        const expandedHeight = Math.max(
-          tabRowHeight + contentAreaHeight + containerPadding,
-          isMobileSize ? 120 : 100 // Ensure minimum usable height
-        );
-        
         return (
           <Box key={`controls-${panelId}`}>
             {/* Single control button with action menu */}
@@ -3093,8 +3059,8 @@ const CanvasCollagePreview = ({
       })}
 
       {/* Focus overlays - darken and blur inactive panels during editing modes */}
-      {(textEditingPanel !== null || Object.values(isTransformMode).some(enabled => enabled) || isReorderMode) && 
-       panelRects.map((rect, index) => {
+      {(textEditingPanel !== null || Object.values(isTransformMode).some(enabled => enabled) || isReorderMode) &&
+       panelRects.map((rect) => {
         const { panelId } = rect;
         
         // Skip overlay for active panels (being edited, in transform mode, or source panel during reorder)
@@ -3121,7 +3087,7 @@ const CanvasCollagePreview = ({
       })}
 
       {/* "Move Here" overlays for destination panels in reorder mode */}
-      {isReorderMode && panelRects.map((rect, index) => {
+      {isReorderMode && panelRects.map((rect) => {
         const { panelId } = rect;
         
         // Only show on destination panels (not the source panel)
@@ -3229,10 +3195,10 @@ const CanvasCollagePreview = ({
       )}
 
       {/* Border drag zones - only visible when not in transform mode, text editing, or reorder mode */}
-      {!Object.values(isTransformMode).some(enabled => enabled) && 
-       textEditingPanel === null && 
+      {!Object.values(isTransformMode).some(enabled => enabled) &&
+       textEditingPanel === null &&
        !isReorderMode &&
-       borderZones.map((zone, index) => (
+       borderZones.map((zone) => (
         <Box
           key={`border-zone-${zone.id || `${zone.type}-${zone.index}`}`}
           onMouseDown={(e) => {

--- a/src/pages/ContributorRequest.js
+++ b/src/pages/ContributorRequest.js
@@ -2,7 +2,7 @@ import { useContext, useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Typography, Container, Grid, Stack, FormControl, InputLabel, Select, MenuItem, } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
-import { API, graphqlOperation } from 'aws-amplify';
+import { API } from 'aws-amplify';
 import { Link, useNavigate } from 'react-router-dom';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import UploadToSeriesPage from '../sections/@dashboard/series/UploadToSeriesPage';

--- a/src/pages/EditorNewProjectPage.js
+++ b/src/pages/EditorNewProjectPage.js
@@ -1,18 +1,12 @@
-import { API, graphqlOperation, Storage } from 'aws-amplify';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Helmet } from 'react-helmet-async';
-import { Container, Typography, Breadcrumbs, Link, Card, CardActionArea, CardContent, Box, Grid, Paper, Input, Chip, Alert } from '@mui/material';
-import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import { Container, Typography, CardActionArea, Grid, Paper, Input, Chip, Alert } from '@mui/material';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import SearchIcon from '@mui/icons-material/Search';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import PhotoLibraryIcon from '@mui/icons-material/PhotoLibrary';
 import BasePage from './BasePage';
-import { createEditorProject } from '../graphql/mutations';
 
 export default function EditorNewProjectPage() {
-  const [uploadedImage, setUploadedImage] = useState(null);
   const navigate = useNavigate();
 
   const handleImageUpload = async (event) => {
@@ -21,7 +15,6 @@ export default function EditorNewProjectPage() {
       const reader = new FileReader();
       reader.onloadend = async function() {
         const base64data = reader.result;
-        setUploadedImage(base64data);
   
         // Create an EditorProject object in GraphQL with an empty state value
         try {

--- a/src/sections/auth/login/SignupForm.js
+++ b/src/sections/auth/login/SignupForm.js
@@ -6,7 +6,6 @@ import { LoadingButton } from '@mui/lab';
 import { API, Auth } from 'aws-amplify';
 // utils
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import { SnackbarContext } from '../../../SnackbarContext';
 // components
 import Iconify from '../../../components/iconify';
@@ -24,7 +23,7 @@ input:-webkit-autofill:active  {
     background-clip: content-box !important;
 `;
 
-export default function SignupForm(props) {
+export default function SignupForm() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
@@ -346,6 +345,3 @@ export default function SignupForm(props) {
   );
 };
 
-SignupForm.propTypes = {
-  setUser: PropTypes.func.isRequired,
-};

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -1,11 +1,9 @@
 // FullScreenSearch.js
 
 import styled from '@emotion/styled';
-import { Button, Fab, Grid, Typography, useMediaQuery, Select, MenuItem, ListSubheader, useTheme } from '@mui/material';
+import { Button, Grid, Typography, useMediaQuery, Select, MenuItem, ListSubheader, useTheme } from '@mui/material';
 import { Box } from '@mui/system';
-import { Favorite, MapsUgc, Shuffle } from '@mui/icons-material';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import { LoadingButton } from '@mui/lab';
 import { useNavigate, useParams, Link, useLocation } from 'react-router-dom';
 import { UserContext } from '../../UserContext';
 import useSearchDetails from '../../hooks/useSearchDetails';
@@ -14,7 +12,7 @@ import HomePageBannerAd from '../../ads/HomePageBannerAd';
 import useSearchDetailsV2 from '../../hooks/useSearchDetailsV2';
 import AddCidPopup from '../../components/ipfs/add-cid-popup';
 import FavoriteToggle from '../../components/FavoriteToggle';
-import useLoadRandomFrame from '../../utils/loadRandomFrame';
+
 import Logo from '../../logo/logo';
 import FixedMobileBannerAd from '../../ads/FixedMobileBannerAd';
 import FloatingActionButtons from '../../components/floating-action-buttons/FloatingActionButtons';
@@ -22,7 +20,6 @@ import FloatingActionButtons from '../../components/floating-action-buttons/Floa
 /* --------------------------------- GraphQL -------------------------------- */
 
 // Define constants for colors and fonts
-const PRIMARY_COLOR = '#4285F4';
 const SECONDARY_COLOR = '#0F9D58';
 const FONT_FAMILY = 'Roboto, sans-serif';
 
@@ -52,21 +49,6 @@ const StyledLabel = styled.label`
   font-size: 14px;
 `;
 
-// Create a button component
-const StyledButton = styled(LoadingButton)`
-  font-family: ${FONT_FAMILY};
-  font-size: 18px;
-  color: #fff;
-  background-color: ${SECONDARY_COLOR};
-  border-radius: 8px;
-  padding: 8px 16px;
-  cursor: pointer;
-  transition: background-color 0.3s;
-
-  &:hover {
-    background-color: ${PRIMARY_COLOR};
-  }
-`;
 
 const StyledSearchInput = styled.input`
   font-family: ${FONT_FAMILY};
@@ -85,20 +67,6 @@ const StyledSearchInput = styled.input`
     outline: none;
   }
 `;
-
-// Combine footer styles into one component
-const StyledFooter = styled('footer')(({ position = 'left' }) => ({
-  bottom: 0,
-  [position]: 0,
-  lineHeight: 0,
-  position: 'fixed',
-  padding: '10px',
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  backgroundColor: 'transparent',
-  zIndex: 1300
-}));
 
 // Height of the fixed navbar on mobile
 const NAVBAR_HEIGHT = 45;
@@ -145,7 +113,6 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
   const [addNewCidOpen, setAddNewCidOpen] = useState(false);
   const { user, shows, defaultShow, handleUpdateDefaultShow } = useContext(UserContext);
   const { pathname } = useLocation();
-  const { loadRandomFrame, loadingRandom, } = useLoadRandomFrame();
 
   const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
 


### PR DESCRIPTION
## Summary
- clean unused props and vars in canvas collage preview
- drop unused imports and state from EditorNewProjectPage
- drop unused graphqlOperation import
- simplify SignupForm props
- remove unused helpers from FullScreenSearch

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883fcc10150832da18881bc8b1d001c