### PR TITLE
Fix remaining lint warnings

### DIFF
--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
 import { Box, IconButton, Typography, Menu, MenuItem, ListItemIcon } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { OpenWith, Check, Place, Crop, DragIndicator } from '@mui/icons-material';
@@ -1612,7 +1613,8 @@ const CanvasCollagePreview = ({
     
     // Border zones have highest priority for cursor
     if (borderZone && !anyPanelInTransformMode && textEditingPanel === null && !isReorderMode) {
-      cursor = borderZone.cursor;
+      const { cursor: borderCursor } = borderZone;
+      cursor = borderCursor;
     } else if (hoveredPanelIndex >= 0 && !borderZone) {
       const panel = panelRects[hoveredPanelIndex];
       
@@ -3272,6 +3274,24 @@ const CanvasCollagePreview = ({
 
     </Box>
   );
+};
+
+CanvasCollagePreview.propTypes = {
+  selectedTemplate: PropTypes.object,
+  panelCount: PropTypes.number,
+  images: PropTypes.arrayOf(PropTypes.string),
+  onPanelClick: PropTypes.func,
+  aspectRatioValue: PropTypes.number,
+  panelImageMapping: PropTypes.object,
+  updatePanelImageMapping: PropTypes.func,
+  borderThickness: PropTypes.number,
+  borderColor: PropTypes.string,
+  panelTransforms: PropTypes.object,
+  updatePanelTransform: PropTypes.func,
+  panelTexts: PropTypes.object,
+  updatePanelText: PropTypes.func,
+  lastUsedTextSettings: PropTypes.object,
+  isGeneratingCollage: PropTypes.bool,
 };
 
 export default CanvasCollagePreview;

--- a/src/components/collage/components/DisclosureCard.js
+++ b/src/components/collage/components/DisclosureCard.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { useTheme } from "@mui/material/styles";
 import {
   Box,
@@ -184,4 +185,18 @@ const DisclosureCard = ({
   );
 };
 
-export default DisclosureCard; 
+DisclosureCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  icon: PropTypes.elementType,
+  children: PropTypes.node,
+  defaultOpen: PropTypes.bool,
+  open: PropTypes.bool,
+  subtitle: PropTypes.string,
+  onToggle: PropTypes.func,
+  sx: PropTypes.object,
+  contentSx: PropTypes.object,
+  isMobile: PropTypes.bool,
+  variant: PropTypes.string,
+};
+
+export default DisclosureCard;

--- a/src/pages/EditorNewProjectPage.js
+++ b/src/pages/EditorNewProjectPage.js
@@ -13,7 +13,7 @@ export default function EditorNewProjectPage() {
     const file = event.target.files[0];
     if (file) {
       const reader = new FileReader();
-      reader.onloadend = async function() {
+      reader.onloadend = async () => {
         const base64data = reader.result;
   
         // Create an EditorProject object in GraphQL with an empty state value

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-unused-vars, func-names */
 
 import { Fragment, forwardRef, memo, useCallback, useContext, useEffect, useRef, useState } from 'react'
+import PropTypes from 'prop-types';
 import { fabric } from 'fabric';
 import { FabricJSCanvas, useFabricJSEditor } from 'fabricjs-react'
 import { styled } from '@mui/material/styles';
@@ -2530,5 +2531,9 @@ const EditorPage = ({ shows }) => {
     </>
   );
 }
+
+EditorPage.propTypes = {
+  shows: PropTypes.array,
+};
 
 export default EditorPage

--- a/src/utils/editorFunctions.js
+++ b/src/utils/editorFunctions.js
@@ -115,10 +115,10 @@ export const addText = (editor, text, append, canvasWidth, canvasHeight) => {
 // Add image layer to canvas
 export const addImageLayer = (editor, imageFile) => new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = function (event) {
+    reader.onload = (event) => {
       const imgObj = new Image();
       imgObj.src = event.target.result;
-      imgObj.onload = function () {
+      imgObj.onload = () => {
         const image = new fabric.Image(imgObj);
 
         const canvasWidth = editor.canvas.getWidth();


### PR DESCRIPTION
## Summary
- add PropTypes to CanvasCollagePreview and DisclosureCard
- enforce destructuring for canvas cursor lookup
- name async callback in EditorNewProjectPage
- add PropTypes for V2EditorPage
- use arrow functions in editorFunctions

## Testing
- `npm run lint`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6884038369ac832d9143f267a20c0a4a