### PR TITLE
Improve performance via async hints and lazy assets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
+  <link rel="preconnect" href="https://faqco2xj5vc27o7qyuw6uhcyxq.appsync-api.us-east-1.amazonaws.com" crossorigin />
   <!-- Favicon -->
   <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/favicon/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon/favicon-32x32.png">

--- a/src/contexts/SubscribeDialog.js
+++ b/src/contexts/SubscribeDialog.js
@@ -1,4 +1,12 @@
-import { AutoFixHighRounded, Close, SupportAgent, Check, Bolt, Share, ThumbUp, Feedback, ArrowBack } from '@mui/icons-material';
+import AutoFixHighRoundedIcon from '@mui/icons-material/AutoFixHighRounded';
+import CloseIcon from '@mui/icons-material/Close';
+import SupportAgentIcon from '@mui/icons-material/SupportAgent';
+import CheckIcon from '@mui/icons-material/Check';
+import BoltIcon from '@mui/icons-material/Bolt';
+import ShareIcon from '@mui/icons-material/Share';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
+import FeedbackIcon from '@mui/icons-material/Feedback';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Box, Button, Card, Chip, CircularProgress, Collapse, Dialog, DialogContent, DialogTitle, Divider, Fade, Grid, IconButton, Typography, useMediaQuery, Stack } from '@mui/material';
 import { API, graphqlOperation } from 'aws-amplify';
 import { createContext, useState, useRef, useEffect, useContext } from 'react';
@@ -248,6 +256,7 @@ export const DialogProvider = ({ children }) => {
             <img
               src="/assets/memeSRC-white.svg"
               alt="memeSRC logo"
+              loading="lazy"
               style={{ height: isCompact ? 24 : 36 }}
             />
             <Typography fontSize={isCompact ? 22 : 28} fontWeight={700}>
@@ -265,7 +274,7 @@ export const DialogProvider = ({ children }) => {
               opacity: 0.4 
             }}
           >
-            <Close />
+            <CloseIcon />
           </IconButton>
         </DialogTitle>
         <Divider />
@@ -359,7 +368,7 @@ export const DialogProvider = ({ children }) => {
                           mr: 2,
                         }}
                       >
-                        <Check sx={{ color: getTextColor(), fontSize: isCompact ? 20 : 24 }} />
+                        <CheckIcon sx={{ color: getTextColor(), fontSize: isCompact ? 20 : 24 }} />
                       </Box>
                       <Typography fontSize={isCompact ? 16 : 18} fontWeight={500}>
                         Zero Ads
@@ -378,7 +387,7 @@ export const DialogProvider = ({ children }) => {
                           mr: 2,
                         }}
                       >
-                        <SupportAgent sx={{ color: getTextColor(), fontSize: isCompact ? 20 : 24 }} />
+                        <SupportAgentIcon sx={{ color: getTextColor(), fontSize: isCompact ? 20 : 24 }} />
                       </Box>
                       <Typography fontSize={isCompact ? 16 : 18} fontWeight={500}>
                         Pro Support
@@ -397,7 +406,7 @@ export const DialogProvider = ({ children }) => {
                           mr: 2,
                         }}
                       >
-                        <Bolt sx={{ color: getTextColor(), fontSize: isCompact ? 20 : 24 }} />
+                        <BoltIcon sx={{ color: getTextColor(), fontSize: isCompact ? 20 : 24 }} />
                       </Box>
                       <Typography fontSize={isCompact ? 16 : 18} fontWeight={500}>
                         Exclusive Features
@@ -422,7 +431,7 @@ export const DialogProvider = ({ children }) => {
                           mr: 2,
                         }}
                       >
-                        <AutoFixHighRounded sx={{ color: getTextColor(), fontSize: isCompact ? 20 : 24 }} />
+                        <AutoFixHighRoundedIcon sx={{ color: getTextColor(), fontSize: isCompact ? 20 : 24 }} />
                       </Box>
                       <Typography fontSize={isCompact ? 16 : 18} fontWeight={500} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                         {getCreditCount()} Magic Credits
@@ -565,7 +574,7 @@ export const DialogProvider = ({ children }) => {
                                     fontWeight: 600,
                                   }}
                                 >
-                                  <AutoFixHighRounded sx={{ fontSize: isCompact ? 23 : 28, mx: 0.5 }} />
+                                  <AutoFixHighRoundedIcon sx={{ fontSize: isCompact ? 23 : 28, mx: 0.5 }} />
                                   {credits}
                                 </Box>
                               </Card>
@@ -705,7 +714,7 @@ export const DialogProvider = ({ children }) => {
                       mr: 2,
                     }}
                   >
-                    <Share sx={{ color: 'common.white' }} />
+                    <ShareIcon sx={{ color: 'common.white' }} />
                   </Box>
                   <Typography variant="body1">Help spread the word</Typography>
                 </Box>
@@ -722,7 +731,7 @@ export const DialogProvider = ({ children }) => {
                       mr: 2,
                     }}
                   >
-                    <ThumbUp sx={{ color: 'common.white' }} />
+                    <ThumbUpIcon sx={{ color: 'common.white' }} />
                   </Box>
                   <Typography variant="body1">Make and share more memes</Typography>
                 </Box>
@@ -739,7 +748,7 @@ export const DialogProvider = ({ children }) => {
                       mr: 2,
                     }}
                   >
-                    <Feedback sx={{ color: 'common.white' }} />
+                    <FeedbackIcon sx={{ color: 'common.white' }} />
                   </Box>
                   <Typography variant="body1">Give feedback and contribute</Typography>
                 </Box>
@@ -786,7 +795,7 @@ export const DialogProvider = ({ children }) => {
                   backgroundColor: 'rgba(255, 255, 255, 0.1)',
                 },
               }}
-              startIcon={<ArrowBack />}
+              startIcon={<ArrowBackIcon />}
             >
               Go Back
             </Button>

--- a/src/pages/AccountPage.js
+++ b/src/pages/AccountPage.js
@@ -1,7 +1,16 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { Box, Typography, Button, Container, Grid, Card, List, ListItem, ListItemIcon, ListItemText, IconButton, Chip, Skeleton, CircularProgress } from '@mui/material';
 import { Navigate, useNavigate } from 'react-router-dom';
-import { Receipt, Download, Block, SupportAgent, Bolt, AutoFixHighRounded, CreditCard, LockOpen, ContentCopy, CheckCircle } from '@mui/icons-material';
+import ReceiptIcon from '@mui/icons-material/Receipt';
+import DownloadIcon from '@mui/icons-material/Download';
+import BlockIcon from '@mui/icons-material/Block';
+import SupportAgentIcon from '@mui/icons-material/SupportAgent';
+import BoltIcon from '@mui/icons-material/Bolt';
+import AutoFixHighRoundedIcon from '@mui/icons-material/AutoFixHighRounded';
+import CreditCardIcon from '@mui/icons-material/CreditCard';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { API, Auth } from 'aws-amplify';
 import { UserContext } from '../UserContext';
 import { useSubscribeDialog } from '../contexts/useSubscribeDialog';
@@ -200,9 +209,9 @@ const AccountPage = () => {
                     }}
                   >
                     {showCopySuccess ? (
-                      <CheckCircle sx={{ fontSize: 16, opacity: 0.7, color: 'success.main' }} />
+                      <CheckCircleIcon sx={{ fontSize: 16, opacity: 0.7, color: 'success.main' }} />
                     ) : (
-                      <ContentCopy sx={{ fontSize: 16, opacity: 0.7 }} />
+                      <ContentCopyIcon sx={{ fontSize: 16, opacity: 0.7 }} />
                     )}
                     <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
                       {userDetails?.user?.sub 
@@ -289,7 +298,7 @@ const AccountPage = () => {
                           alignItems: 'center',
                           gap: 1
                         }}>
-                          <CreditCard sx={{ fontSize: 20 }} />
+                          <CreditCardIcon sx={{ fontSize: 20 }} />
                           Your last payment failed. Please update your payment method to continue using Pro features.
                         </Typography>
                         <Button
@@ -368,12 +377,12 @@ const AccountPage = () => {
                     )}
                   </Box>
                 </Box>
-                {[
-                  { icon: <Block />, text: 'Ad-Free Experience' },
-                  { icon: <SupportAgent />, text: 'Priority Support' },
-                  { icon: <Bolt />, text: 'Early Access to New Features' },
-                  { icon: <AutoFixHighRounded />, text: 'Monthly Magic Credits' },
-                ].map(({ icon, text }) => (
+                  {[
+                    { icon: <BlockIcon />, text: 'Ad-Free Experience' },
+                    { icon: <SupportAgentIcon />, text: 'Priority Support' },
+                    { icon: <BoltIcon />, text: 'Early Access to New Features' },
+                    { icon: <AutoFixHighRoundedIcon />, text: 'Monthly Magic Credits' },
+                  ].map(({ icon, text }) => (
                   <Box 
                     key={text}
                     sx={{ 
@@ -431,7 +440,7 @@ const AccountPage = () => {
                       },
                     }}
                   >
-                    <LockOpen sx={{ fontSize: 20 }} />
+                    <LockOpenIcon sx={{ fontSize: 20 }} />
                     <Typography 
                       variant="body1"
                       sx={{ 
@@ -552,7 +561,7 @@ const AccountPage = () => {
                   onClick={() => openInvoicePDF(invoice.hosted_invoice_url)}
                 >
                   <ListItemIcon>
-                    <Receipt />
+                    <ReceiptIcon />
                   </ListItemIcon>
                   <ListItemText
                     primary={`Invoice #${invoice.number}`}
@@ -567,7 +576,7 @@ const AccountPage = () => {
                     }}
                     disabled={!invoice.invoice_pdf}
                   >
-                    <Download />
+                    <DownloadIcon />
                   </IconButton>
                 </ListItem>
               ))}

--- a/src/pages/CollagePageLegacy.js
+++ b/src/pages/CollagePageLegacy.js
@@ -1017,6 +1017,7 @@ export default function CollagePage() {
               <img
                 src="/assets/memeSRC-white.svg"
                 alt="memeSRC logo"
+                loading="lazy"
                 style={{ height: 48, marginBottom: -15 }}
               />
               <Typography variant="h3" textAlign="center">
@@ -1144,7 +1145,7 @@ export default function CollagePage() {
                     <>
                       <ImageContainer ref={(el) => { imageRefs.current[index] = el; }}>
                         <ImageWrapper>
-                          <img src={image.src} alt={`layer ${index + 1}`} style={{ width: "100%" }} />
+                          <img src={image.src} alt={`layer ${index + 1}`} loading="lazy" style={{ width: "100%" }} />
                           <DeleteButton className="delete-button" onClick={() => deleteImage(index)}>
                             <Close />
                           </DeleteButton>

--- a/src/pages/DashboardSeriesPage.js
+++ b/src/pages/DashboardSeriesPage.js
@@ -7,16 +7,14 @@ import { useState, useEffect, Fragment, useContext } from 'react';
 import { API, graphqlOperation } from 'aws-amplify';
 import { LoadingButton } from '@mui/lab';
 import { useNavigate } from 'react-router-dom';
-import {
-  ArrowDropDown,
-  ChangeHistoryOutlined,
-  CheckCircle,
-  InfoOutlined,
-  ListAlt,
-  Pending,
-  Poll,
-  StorageOutlined,
-} from '@mui/icons-material';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import ChangeHistoryOutlinedIcon from '@mui/icons-material/ChangeHistoryOutlined';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import ListAltIcon from '@mui/icons-material/ListAlt';
+import PendingIcon from '@mui/icons-material/Pending';
+import PollIcon from '@mui/icons-material/Poll';
+import StorageOutlinedIcon from '@mui/icons-material/StorageOutlined';
 import { listSeriesData, updateSeriesData } from '../utils/migrateSeriesData';
 import Iconify from '../components/iconify';
 import { createSeries, updateSeries, deleteSeries } from '../graphql/mutations';
@@ -466,7 +464,7 @@ export default function DashboardSeriesPage() {
             aria-haspopup="true"
             onClick={handleOptionsMenuClick}
             variant="contained"
-            startIcon={<ArrowDropDown />}
+            startIcon={<ArrowDropDownIcon />}
           >
             Options
           </Button>
@@ -490,7 +488,7 @@ export default function DashboardSeriesPage() {
               </Button>
             </MenuItem>
             <MenuItem onClick={handleOptionsMenuClose}>
-              <Button fullWidth variant="contained" startIcon={<StorageOutlined />} onClick={tvdbIdMigration}>
+              <Button fullWidth variant="contained" startIcon={<StorageOutlinedIcon />} onClick={tvdbIdMigration}>
                 Migrate Data
               </Button>
             </MenuItem>
@@ -499,7 +497,7 @@ export default function DashboardSeriesPage() {
                 handleChangeAllStatus();
                 handleOptionsMenuClose();
               }}>
-              <Button fullWidth variant="contained" startIcon={<ChangeHistoryOutlined />}>
+              <Button fullWidth variant="contained" startIcon={<ChangeHistoryOutlinedIcon />}>
                 Change All Status
               </Button>
             </MenuItem>
@@ -516,7 +514,7 @@ export default function DashboardSeriesPage() {
             <Tab
               label={
                 <Box display="flex" alignItems="center">
-                  <ListAlt color="success" sx={{ mr: 1 }} />
+                  <ListAltIcon color="success" sx={{ mr: 1 }} />
                   All
                 </Box>
               }
@@ -525,7 +523,7 @@ export default function DashboardSeriesPage() {
             <Tab
               label={
                 <Box display="flex" alignItems="center">
-                  <CheckCircle color="success" sx={{ mr: 1 }} />
+                  <CheckCircleIcon color="success" sx={{ mr: 1 }} />
                   Live
                 </Box>
               }
@@ -534,7 +532,7 @@ export default function DashboardSeriesPage() {
             <Tab
               label={
                 <Box display="flex" alignItems="center">
-                  <Poll color="warning" sx={{ mr: 1 }} />
+                  <PollIcon color="warning" sx={{ mr: 1 }} />
                   Votable
                 </Box>
               }
@@ -543,7 +541,7 @@ export default function DashboardSeriesPage() {
             <Tab
               label={
                 <Box display="flex" alignItems="center">
-                  <Pending color="action" sx={{ mr: 1 }} />
+                  <PendingIcon color="action" sx={{ mr: 1 }} />
                   Requested
                 </Box>
               }
@@ -552,7 +550,7 @@ export default function DashboardSeriesPage() {
             <Tab
               label={
                 <Box display="flex" alignItems="center">
-                  <InfoOutlined color="error" sx={{ mr: 1 }} />
+                  <InfoOutlinedIcon color="error" sx={{ mr: 1 }} />
                   Other
                 </Box>
               }
@@ -678,7 +676,12 @@ export default function DashboardSeriesPage() {
                     seriesSeasons.map((season) =>
                       season.type.id === 1 ? (
                         <Grid item xs={6} md={4} key={season.id}>
-                          <img src={season.image} alt="season artwork" style={{ width: '100%', height: 'auto' }} />
+                          <img
+                            src={season.image}
+                            alt="season artwork"
+                            loading="lazy"
+                            style={{ width: '100%', height: 'auto' }}
+                          />
                           <Typography component="h6" variant="h6">
                             Season {season.number}
                           </Typography>

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -6,7 +6,27 @@ import { useParams, useNavigate, useLocation, useSearchParams } from 'react-rout
 import { TwitterPicker } from 'react-color';
 import MuiAlert from '@mui/material/Alert';
 import { Accordion, AccordionDetails, AccordionSummary, Button, ButtonGroup, Card, CircularProgress, Container, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Fab, Grid, IconButton, List, ListItem, ListItemIcon, ListItemText, Popover, Slider, Snackbar, Stack, Tab, Tabs, TextField, Typography, useTheme } from '@mui/material';
-import { Add, AddCircleOutline, AutoFixHigh, AutoFixHighRounded, CheckCircleOutline, Close, ClosedCaption, ContentCopy, FormatColorFill, GpsFixed, GpsNotFixed, HighlightOffRounded, HistoryToggleOffRounded, IosShare, Menu, Redo, Save, Share, Undo, ZoomIn, ZoomOut } from '@mui/icons-material';
+import AddIcon from '@mui/icons-material/Add';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import AutoFixHighRoundedIcon from '@mui/icons-material/AutoFixHighRounded';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import CloseIcon from '@mui/icons-material/Close';
+import ClosedCaptionIcon from '@mui/icons-material/ClosedCaption';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import FormatColorFillIcon from '@mui/icons-material/FormatColorFill';
+import GpsFixedIcon from '@mui/icons-material/GpsFixed';
+import GpsNotFixedIcon from '@mui/icons-material/GpsNotFixed';
+import HighlightOffRoundedIcon from '@mui/icons-material/HighlightOffRounded';
+import HistoryToggleOffRoundedIcon from '@mui/icons-material/HistoryToggleOffRounded';
+import IosShareIcon from '@mui/icons-material/IosShare';
+import MenuIcon from '@mui/icons-material/Menu';
+import RedoIcon from '@mui/icons-material/Redo';
+import SaveIcon from '@mui/icons-material/Save';
+import ShareIcon from '@mui/icons-material/Share';
+import UndoIcon from '@mui/icons-material/Undo';
+import ZoomInIcon from '@mui/icons-material/ZoomIn';
+import ZoomOutIcon from '@mui/icons-material/ZoomOut';
 import { API, Storage, graphqlOperation } from 'aws-amplify';
 import { Box } from '@mui/system';
 import { Helmet } from 'react-helmet-async';
@@ -228,7 +248,21 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
 
   // Warm up the UUID function for faster save dialog response
   useEffect(() => {
-    API.get('publicapi', '/uuid', { queryStringParameters: { warmup: true } })
+    const idleId = 'requestIdleCallback' in window
+      ? window.requestIdleCallback(() => {
+          API.get('publicapi', '/uuid', { queryStringParameters: { warmup: true } })
+        })
+      : setTimeout(() => {
+          API.get('publicapi', '/uuid', { queryStringParameters: { warmup: true } })
+        }, 1000)
+
+    return () => {
+      if ('cancelIdleCallback' in window) {
+        window.cancelIdleCallback(idleId)
+      } else {
+        clearTimeout(idleId)
+      }
+    }
   }, [])
 
   useEffect(() => {
@@ -1257,17 +1291,17 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
 
                       <ButtonGroup variant="contained" size="small">
                         <IconButton disabled={(editorStates.length <= 1)} onClick={undo}>
-                          <Undo />
+                          <UndoIcon />
                         </IconButton>
                         <IconButton disabled={(futureStates.length === 0)} onClick={redo}>
-                          <Redo />
+                          <RedoIcon />
                         </IconButton>
                       </ButtonGroup>
 
                       <Button
                         variant="contained"
                         size="medium"
-                        startIcon={<Save />}
+                        startIcon={<SaveIcon />}
                         onClick={handleClickDialogOpen}
                         sx={{ zIndex: '50', backgroundColor: '#4CAF50', '&:hover': { backgroundColor: '#45a045' } }}
                       >
@@ -1330,7 +1364,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                         }}
                         icon={
                           <Box display="flex" alignItems="center" marginX={-1}>
-                            <HistoryToggleOffRounded fontSize='small' sx={{ mr: 1 }} />
+                            <HistoryToggleOffRoundedIcon fontSize='small' sx={{ mr: 1 }} />
                             Timing
                           </Box>
                         }
@@ -1344,7 +1378,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                       }}
                       icon={
                         <Box display="flex" alignItems="center" marginX={-1}>
-                          <ClosedCaption fontSize='small' sx={{ mr: 1 }} />
+                          <ClosedCaptionIcon fontSize='small' sx={{ mr: 1 }} />
                           Captions
                         </Box>
                       }
@@ -1358,7 +1392,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                       }}
                       icon={
                         <Box display="flex" alignItems="center" marginX={-1}>
-                          <AutoFixHighRounded fontSize='small' sx={{ mr: 1 }} />
+                          <AutoFixHighRoundedIcon fontSize='small' sx={{ mr: 1 }} />
                           Magic
                         </Box>
                       }
@@ -1411,7 +1445,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                                     }}
                                     onClick={() => deleteLayer(index)}
                                   >
-                                    <HighlightOffRounded color="error" />
+                                    <HighlightOffRoundedIcon color="error" />
                                   </Fab>
                                 </div>
                               </Grid>
@@ -1442,7 +1476,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                                     }}
                                     onClick={() => deleteLayer(index)}
                                   >
-                                    <HighlightOffRounded color="error" />
+                                    <HighlightOffRoundedIcon color="error" />
                                   </Fab>
                                 </div>
                               </Grid>
@@ -1456,7 +1490,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                           onClick={() => addText('text', true)}
                           fullWidth
                           sx={{ zIndex: '50', marginTop: '20px' }}
-                          startIcon={<AddCircleOutline />}
+                          startIcon={<AddCircleOutlineIcon />}
                         >
                           Add text layer
                         </Button>
@@ -1473,7 +1507,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                           onClick={() => fileInputRef.current.click()}
                           fullWidth
                           sx={{ zIndex: '50', marginBottom: '20px' }}
-                          startIcon={<AddPhotoAlternate />}
+                          startIcon={<AddPhotoAlternateIcon />}
                         >
                           Add image layer
                         </Button>
@@ -1518,13 +1552,13 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                         }}
                       >
                         <Tab
-                          icon={<AutoFixHigh fontSize='small' />}
+                          icon={<AutoFixHighIcon fontSize='small' />}
                           label="Eraser"
                           value="erase"
                           style={{ color: promptEnabled === 'erase' ? 'limegreen' : undefined }}
                         />
                         <Tab
-                          icon={<FormatColorFill fontSize='small' />}
+                          icon={<FormatColorFillIcon fontSize='small' />}
                           label="Fill"
                           value="fill"
                           style={{ color: promptEnabled === 'fill' ? 'limegreen' : undefined }}
@@ -1616,7 +1650,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                     onClick={handleClickDialogOpen}
                     fullWidth
                     sx={{ marginTop: 2, zIndex: '50', backgroundColor: '#4CAF50', '&:hover': { backgroundColor: '#45a045' } }}
-                    startIcon={<Share />}
+                    startIcon={<ShareIcon />}
                     size="large"
                   >
                     Save/Copy/Share
@@ -1628,9 +1662,9 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                       <AccordionSummary sx={{ paddingX: 1.55, textAlign: "center" }} onClick={handleSubtitlesExpand} >
                         <Typography marginRight="auto" fontWeight="bold" color="#CACACA" fontSize={14.8}>
                           {subtitlesExpanded ? (
-                            <Close style={{ verticalAlign: 'middle', marginTop: '-3px', marginRight: '10px' }} />
+                            <CloseIcon style={{ verticalAlign: 'middle', marginTop: '-3px', marginRight: '10px' }} />
                           ) : (
-                            <Menu style={{ verticalAlign: 'middle', marginTop: '-3px', marginRight: '10px' }} />
+                            <MenuIcon style={{ verticalAlign: 'middle', marginTop: '-3px', marginRight: '10px' }} />
                           )}
                           {subtitlesExpanded ? 'Hide' : 'View'} Nearby Subtitles
                         </Typography>
@@ -1673,7 +1707,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                                         <CircularProgress size={20} sx={{ color: '#565656' }} />
                                       ) : result?.subtitle.replace(/\n/g, ' ') ===
                                         defaultSubtitle.replace(/\n/g, ' ') ? (
-                                        <GpsFixed
+                                        <GpsFixedIcon
                                           sx={{
                                             color:
                                               result?.subtitle.replace(/\n/g, ' ') ===
@@ -1684,7 +1718,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                                           }}
                                         />
                                       ) : (
-                                        <GpsNotFixed sx={{ color: 'rgb(89, 89, 89)', cursor: 'pointer' }} />
+                                        <GpsNotFixedIcon sx={{ color: 'rgb(89, 89, 89)', cursor: 'pointer' }} />
                                       )}
                                     </Fab>
                                   </ListItemIcon>
@@ -1723,7 +1757,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                                         handleSnackbarOpen();
                                       }}
                                     >
-                                      <ContentCopy sx={{ color: 'rgb(89, 89, 89)' }} />
+                                      <ContentCopyIcon sx={{ color: 'rgb(89, 89, 89)' }} />
                                     </Fab>
                                     <Fab
                                       size="small"
@@ -1738,7 +1772,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                                       }}
                                       onClick={() => addText(result?.subtitle.replace(/\n/g, ' '), true)}
                                     >
-                                      <Add sx={{ color: 'rgb(89, 89, 89)', cursor: 'pointer' }} />
+                                      <AddIcon sx={{ color: 'rgb(89, 89, 89)', cursor: 'pointer' }} />
                                     </Fab>
                                     {/* <Fab
                                                                               size="small"
@@ -1753,7 +1787,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                                                                           {loading ? (
                                                                               <CircularProgress size={20} sx={{ color: "#565656"}} />
                                                                           ) : (
-                                                                              (result?.subtitle.replace(/\n/g, " ") === defaultSubtitle.replace(/\n/g, " ")) ? <GpsFixed sx={{ color: (result?.subtitle.replace(/\n/g, " ") === defaultSubtitle?.replace(/\n/g, " ")) ? 'rgb(50, 50, 50)' : 'rgb(89, 89, 89)', cursor: "pointer"}} /> : <ArrowForward sx={{ color: "rgb(89, 89, 89)", cursor: "pointer"}} /> 
+                                                                              (result?.subtitle.replace(/\n/g, " ") === defaultSubtitle.replace(/\n/g, " ")) ? <GpsFixedIcon sx={{ color: (result?.subtitle.replace(/\n/g, " ") === defaultSubtitle?.replace(/\n/g, " ")) ? 'rgb(50, 50, 50)' : 'rgb(89, 89, 89)', cursor: "pointer"}} /> : <ArrowForwardIcon sx={{ color: "rgb(89, 89, 89)", cursor: "pointer"}} />
                                                                           )}
                                                                           </Fab> */}
                                   </ListItemIcon>
@@ -1934,6 +1968,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                     src={`https://i${process.env.REACT_APP_USER_BRANCH === 'prod' ? 'prod' : `-${process.env.REACT_APP_USER_BRANCH}`
                       }.memesrc.com/${generatedImageFilename}`}
                     alt="generated meme"
+                    loading="lazy"
                   />
                 )}
                 {imageUploading && (
@@ -1971,7 +2006,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                         files: [shareImageFile],
                       });
                     }}
-                    startIcon={<IosShare />}
+                    startIcon={<IosShareIcon />}
                   >
                     Share
                   </Button>
@@ -1987,7 +2022,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                     navigator.clipboard.write([new ClipboardItem({ 'image/png': imageBlob })]);
                     handleSnackbarOpen();
                   }}
-                  startIcon={<ContentCopy />}
+                  startIcon={<ContentCopyIcon />}
                 >
                   Copy
                 </Button>
@@ -1998,7 +2033,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                   sx={{ marginBottom: 2, padding: '12px 16px' }}
                   autoFocus
                   onClick={handleDialogClose}
-                  startIcon={<Close />}
+                  startIcon={<CloseIcon />}
                 >
                   Close
                 </Button>
@@ -2049,6 +2084,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                   <img
                     src={image}
                     alt="placeholder"
+                    loading="lazy"
                     style={{
                       width: '100%',
                       aspectRatio: `${editorAspectRatio}/1`,
@@ -2068,7 +2104,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                         color: 'white'
                       }}
                     >
-                      <CheckCircleOutline />
+                      <CheckCircleOutlineIcon />
                     </Fab>
                   )}
                 </div>
@@ -2114,7 +2150,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
           }}
           onClick={() => setVariationDisplayColumns(prev => (prev === 2 ? 1 : 2))}
         >
-          {variationDisplayColumns === 2 ? <ZoomIn /> : <ZoomOut />}
+          {variationDisplayColumns === 2 ? <ZoomInIcon /> : <ZoomOutIcon />}
         </Fab>
       </Dialog>
     </>

--- a/src/pages/FacebookAuthDemo.js
+++ b/src/pages/FacebookAuthDemo.js
@@ -164,6 +164,7 @@ export default function FacebookAuthDemo() {
                         <img
                           src={profileInfo.picture.data.url}
                           alt="Profile"
+                          loading="lazy"
                           style={{ width: '100px', height: '100px', borderRadius: '50%', marginBottom: '16px' }}
                         />
                       )}

--- a/src/pages/FavoritesPage.js
+++ b/src/pages/FavoritesPage.js
@@ -177,6 +177,7 @@ const FavoritesPage = () => {
             <img
               src="/assets/memeSRC-white.svg"
               alt="memeSRC logo"
+              loading="lazy"
               style={{ height: 48, marginBottom: -15 }}
             />
             <Typography variant="h3" textAlign="center">

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -30,11 +30,24 @@ export default function SearchPage({ metadata }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Make sure API functions are warm
-    API.get('publicapi', '/search', { queryStringParameters: { warmup: true } })
-    API.get('publicapi', '/random', { queryStringParameters: { warmup: true } })
-    // Prep sessionID for future use
-    prepSessionID()
+    const runWarmups = () => {
+      API.get('publicapi', '/search', { queryStringParameters: { warmup: true } })
+      API.get('publicapi', '/random', { queryStringParameters: { warmup: true } })
+      // Prep sessionID for future use
+      prepSessionID()
+    }
+
+    const idleId = 'requestIdleCallback' in window
+      ? window.requestIdleCallback(runWarmups)
+      : setTimeout(runWarmups, 1000)
+
+    return () => {
+      if ('cancelIdleCallback' in window) {
+        window.cancelIdleCallback(idleId)
+      } else {
+        clearTimeout(idleId)
+      }
+    }
   }, [])
 
   const handleSearch = useCallback((e) => {

--- a/src/pages/ProSupport.js
+++ b/src/pages/ProSupport.js
@@ -114,6 +114,7 @@ export default function ProSupport() {
                 <img
                   src="/assets/memeSRC-white.svg"
                   alt="memeSRC logo"
+                  loading="lazy"
                   style={{ height: 48, marginBottom: -15 }}
                 />
                 <Typography variant="h3" textAlign="center">

--- a/src/pages/SubtitleViewerPage.js
+++ b/src/pages/SubtitleViewerPage.js
@@ -226,11 +226,12 @@ const SubtitleViewerPage = () => {
                 >
                   <TableCell style={{ width: 160 }}>
                     {frameImages[subtitle.middle_frame] && (
-                      <img 
-                        src={frameImages[subtitle.middle_frame]} 
+                      <img
+                        src={frameImages[subtitle.middle_frame]}
                         alt={`Frame ${subtitle.middle_frame}`}
-                        style={{ 
-                          width: '100%', 
+                        loading="lazy"
+                        style={{
+                          width: '100%',
                           height: 'auto',
                           display: loadedImages[subtitle.middle_frame] ? 'block' : 'none',
                           cursor: 'pointer'

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -292,7 +292,21 @@ const EditorPage = ({ shows }) => {
 
   // Warm up the UUID function for faster save dialog response
   useEffect(() => {
-    API.get('publicapi', '/uuid', { queryStringParameters: { warmup: true } })
+    const idleId = 'requestIdleCallback' in window
+      ? window.requestIdleCallback(() => {
+          API.get('publicapi', '/uuid', { queryStringParameters: { warmup: true } })
+        })
+      : setTimeout(() => {
+          API.get('publicapi', '/uuid', { queryStringParameters: { warmup: true } })
+        }, 1000)
+
+    return () => {
+      if ('cancelIdleCallback' in window) {
+        window.cancelIdleCallback(idleId)
+      } else {
+        clearTimeout(idleId)
+      }
+    }
   }, [])
 
   useEffect(() => {

--- a/src/pages/VotingPage.js
+++ b/src/pages/VotingPage.js
@@ -32,7 +32,17 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-import { ArrowUpward, ArrowDownward, Search, Close, ThumbUp, Whatshot, Lock, NewReleasesOutlined, Refresh, AutoFixHighRounded, ThumbDown } from '@mui/icons-material';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import SearchIcon from '@mui/icons-material/Search';
+import CloseIcon from '@mui/icons-material/Close';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
+import WhatshotIcon from '@mui/icons-material/Whatshot';
+import LockIcon from '@mui/icons-material/Lock';
+import NewReleasesOutlinedIcon from '@mui/icons-material/NewReleasesOutlined';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import AutoFixHighRoundedIcon from '@mui/icons-material/AutoFixHighRounded';
+import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import FlipMove from 'react-flip-move';
 import { useLocation, useNavigate, Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
@@ -1220,11 +1230,11 @@ export default function VotingPage() {
                   },
                 }}
               >
-                <ThumbUp color="success" sx={{ mr: 1 }} />
+                <ThumbUpIcon color="success" sx={{ mr: 1 }} />
                 Most Upvoted
               </ToggleButton>
               <ToggleButton value="combined" aria-label="battleground">
-                <Whatshot color="error" sx={{ mr: 1 }} />
+                <WhatshotIcon color="error" sx={{ mr: 1 }} />
                 Battleground
               </ToggleButton>
             </ToggleButtonGroup>
@@ -1243,7 +1253,7 @@ export default function VotingPage() {
               All
             </ToggleButton>
             <ToggleButton value="hideAvailable" aria-label="hide available">
-              <NewReleasesOutlined sx={{ mr: 1 }} />
+              <NewReleasesOutlinedIcon sx={{ mr: 1 }} />
               Requested
             </ToggleButton>
             <ToggleButton value="requested" aria-label="requested">
@@ -1285,7 +1295,7 @@ export default function VotingPage() {
                     ...params.InputProps,
                     startAdornment: (
                       <InputAdornment position="start">
-                        <Search />
+                        <SearchIcon />
                       </InputAdornment>
                     ),
                     endAdornment: (searchText || isSearching) && (
@@ -1298,7 +1308,7 @@ export default function VotingPage() {
                           {isSearching ? (
                             <CircularProgress size={20} sx={{ color: 'white' }} />
                           ) : (
-                            <Close />
+                            <CloseIcon />
                           )}
                         </IconButton>
                       </InputAdornment>
@@ -1344,7 +1354,7 @@ export default function VotingPage() {
                 {isRefreshing ? (
                   <CircularProgress size={24} />
                 ) : (
-                  <Refresh />
+                  <RefreshIcon />
                 )}
               </IconButton>
             )}
@@ -1440,6 +1450,7 @@ export default function VotingPage() {
                                       <img
                                         src={show.image || 'path/to/placeholder-image.jpg'}
                                         alt={show.name}
+                                        loading="lazy"
                                         style={{
                                           ...showImageStyle,
                                           display: loadedImages[show.id] ? 'block' : 'none',
@@ -1478,7 +1489,7 @@ export default function VotingPage() {
                                         color="success.main"
                                         sx={{ fontSize: '0.7rem', opacity: 0.6 }}
                                       >
-                                        <ArrowUpward
+                                        <ArrowUpwardIcon
                                           fontSize="small"
                                           sx={{ verticalAlign: 'middle' }}
                                         />
@@ -1491,7 +1502,7 @@ export default function VotingPage() {
                                           ml={1}
                                           sx={{ fontSize: '0.7rem', opacity: 0.6 }}
                                         >
-                                          <ArrowDownward
+                                          <ArrowDownwardIcon
                                             fontSize="small"
                                             sx={{ verticalAlign: 'middle' }}
                                           />
@@ -1587,11 +1598,11 @@ export default function VotingPage() {
                                                 }}
                                               >
                                                 {userCanVote ? (
-                                                  <ArrowUpward />
+                                                  <ArrowUpwardIcon />
                                                 ) : isUpvoted ? (
-                                                  <ArrowUpward sx={{ color: 'success.main' }} />
+                                                  <ArrowUpwardIcon sx={{ color: 'success.main' }} />
                                                 ) : (
-                                                  <ArrowUpward />
+                                                  <ArrowUpwardIcon />
                                                 )}
                                               </StyledFab>
                                             </MagicVoteWrapper>
@@ -1678,9 +1689,9 @@ export default function VotingPage() {
                                                 }}
                                               >
                                                 {isDownvoted ? (
-                                                  <ArrowDownward sx={{ color: 'error.main' }} />
+                                                  <ArrowDownwardIcon sx={{ color: 'error.main' }} />
                                                 ) : (
-                                                  <ArrowDownward />
+                                                  <ArrowDownwardIcon />
                                                 )}
                                               </StyledFab>
                                             </MagicVoteWrapper>
@@ -1767,11 +1778,11 @@ export default function VotingPage() {
                                                 }}
                                               >
                                                 {userCanVote ? (
-                                                  <ThumbUp />
+                                                  <ThumbUpIcon />
                                                 ) : isUpvoted ? (
-                                                  <ThumbUp sx={{ color: 'success.main' }} />
+                                                  <ThumbUpIcon sx={{ color: 'success.main' }} />
                                                 ) : (
-                                                  <Lock />
+                                                  <LockIcon />
                                                 )}
                                               </StyledFab>
                                             </MagicVoteWrapper>
@@ -2034,11 +2045,11 @@ export default function VotingPage() {
             '&:last-child': { pb: '16px' },
           }
         }}>
-          <AutoFixHighRounded 
-            sx={{ 
-              color: magicVotesEnabled ? 'black' : theme.palette.success.main, 
+          <AutoFixHighRoundedIcon
+            sx={{
+              color: magicVotesEnabled ? 'black' : theme.palette.success.main,
               fontSize: '2rem',
-            }} 
+            }}
           />
           <Typography 
             variant="body1" 
@@ -2101,7 +2112,7 @@ export default function VotingPage() {
               color: 'white',
             }}
           >
-            <Close />
+            <CloseIcon />
           </IconButton>
 
           
@@ -2182,7 +2193,7 @@ export default function VotingPage() {
                       fontSize: { xs: '0.7rem', sm: '0.75rem' } // Slightly smaller on mobile
                     }}
                   >
-                    {multiplier !== 1 && <AutoFixHighRounded sx={{ fontSize: '1rem' }} />}
+                    {multiplier !== 1 && <AutoFixHighRoundedIcon sx={{ fontSize: '1rem' }} />}
                     {multiplier === 1 ? 'Free' : multiplier === 5 ? '1\u00A0credit' : '2\u00A0credits'}
                   </Typography>
                 </Box>
@@ -2224,9 +2235,9 @@ export default function VotingPage() {
             }}
           >
             {/* ThumbUp Icon if boosting upvote or ThumbDown Icon if boosting downvote */}
-            {magicVoteBoost > 0 ? 
-              <ThumbUp sx={{ fontSize: '1.5rem', mr: 1 }} /> : 
-              <ThumbDown sx={{ fontSize: '1.5rem', mr: 1 }} />}
+            {magicVoteBoost > 0 ?
+              <ThumbUpIcon sx={{ fontSize: '1.5rem', mr: 1 }} /> :
+              <ThumbDownIcon sx={{ fontSize: '1.5rem', mr: 1 }} />}
             {(() => {
               const requiredCredits = magicVoteMultiplier === 1 ? 0 : magicVoteMultiplier === 5 ? 1 : 2;
               const hasEnoughCredits = user?.userDetails?.credits >= requiredCredits;

--- a/src/utils/adsenseLoader.js
+++ b/src/utils/adsenseLoader.js
@@ -14,15 +14,25 @@ export const useAdsenseLoader = () => {
       script.src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1307598869123774";
       script.async = true;
       script.crossOrigin = "anonymous";
-      document.body.appendChild(script);
-      adsenseLoaded = true;
+
+      const loadScript = () => {
+        document.body.appendChild(script);
+        adsenseLoaded = true;
+      };
+
+      const idleId = 'requestIdleCallback' in window
+        ? window.requestIdleCallback(loadScript)
+        : setTimeout(loadScript, 1000);
 
       return () => {
-        // Cleanup if user becomes a subscriber
-        if (user?.userDetails?.subscriptionStatus === 'active') {
+        if ('cancelIdleCallback' in window) {
+          window.cancelIdleCallback(idleId);
+        } else {
+          clearTimeout(idleId);
+        }
+        if (adsenseLoaded && user?.userDetails?.subscriptionStatus === 'active') {
           document.body.removeChild(script);
           adsenseLoaded = false;
-          // Clear any existing ads
           const ads = document.getElementsByClassName('adsbygoogle');
           Array.from(ads).forEach(ad => ad.remove());
         }


### PR DESCRIPTION
## Summary
- preconnect to AWS AppSync endpoint for faster API calls
- mark offscreen images with `loading="lazy"`
- use specific MUI icon imports for better tree shaking
- defer API warmups and AdSense loading until browser is idle

## Testing
- `CI=true npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6885566d15cc832da4125d0ef4132244