### PR TITLE
Optimize runtime calls and imports

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,12 @@
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
+  <!-- Preconnect to GraphQL endpoint to speed up API requests -->
+  <link rel="preconnect" href="https://faqco2xj5vc27o7qyuw6uhcyxq.appsync-api.us-east-1.amazonaws.com" crossorigin>
+  <link rel="dns-prefetch" href="https://faqco2xj5vc27o7qyuw6uhcyxq.appsync-api.us-east-1.amazonaws.com">
+  <!-- Preconnect to Google Tag Manager for faster script loading -->
+  <link rel="preconnect" href="https://www.googletagmanager.com">
+
 
   <!-- Google Tag Manager -->
   <script>(function (w, d, s, l, i) {

--- a/src/components/ImageEditorControls.js
+++ b/src/components/ImageEditorControls.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ArrowDownward, ArrowUpward } from '@mui/icons-material';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import { IconButton, Tooltip, Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 
@@ -8,7 +9,7 @@ const ImageEditorControls = ({ index, moveLayerUp, moveLayerDown, src }) => (
     <Typography variant="h5" marginY={1}><b>Layer {index + 1} (image)</b></Typography>
     <div style={{ display: 'flex', alignItems: 'center' }}>
       <div style={{ marginLeft: '10px', height: '50px', width: '50px', overflow: 'hidden' }}>
-        <img src={src} alt={`thumbnail-${index}`} style={{ height: '100%', objectFit: 'cover' }} />
+        <img src={src} alt={`thumbnail-${index}`} loading="lazy" style={{ height: '100%', objectFit: 'cover' }} />
       </div>
       {/* <Tooltip title="Delete Layer">
           <IconButton aria-label="delete" onClick={() => deleteLayer(index)}>
@@ -17,12 +18,12 @@ const ImageEditorControls = ({ index, moveLayerUp, moveLayerDown, src }) => (
       </Tooltip> */}
       <Tooltip title="Move Layer Up">
         <IconButton aria-label="move up" onClick={() => moveLayerUp(index)}>
-          <ArrowUpward />
+          <ArrowUpwardIcon />
         </IconButton>
       </Tooltip>
       <Tooltip title="Move Layer Down">
         <IconButton aria-label="move down" onClick={() => moveLayerDown(index)}>
-          <ArrowDownward />
+          <ArrowDownwardIcon />
         </IconButton>
       </Tooltip>
       {/* Add more controls as needed */}

--- a/src/components/TvdbSearch/TvdbSearch.js
+++ b/src/components/TvdbSearch/TvdbSearch.js
@@ -239,6 +239,7 @@ export default function TvdbSearch({ onSelect = () => {}, onClear = () => {}, ty
                                                 <img
                                                     src={option.fullResult.image_url}
                                                     alt={option.label}
+                                                    loading="lazy"
                                                     style={{ height: '100px', marginRight: '10px' }}
                                                 />
                                                 <div style={{ paddingLeft: 8 }}>

--- a/src/components/collage/components/CollageResultDialog.js
+++ b/src/components/collage/components/CollageResultDialog.js
@@ -211,6 +211,7 @@ export default function CollageResultDialog({ open, onClose, finalImage }) {
                 <img
                   src={imageUrl}
                   alt="Generated Collage"
+                  loading="lazy"
                   style={{
                     maxWidth: '100%',
                     maxHeight: '100%',

--- a/src/components/collage/components/UpgradeMessage.js
+++ b/src/components/collage/components/UpgradeMessage.js
@@ -310,10 +310,11 @@ const UpgradeMessage = ({
                   Early Access
                 </Box>
                 
-                <img 
-                  src={previewImage} 
-                  alt={`${featureName} Preview`} 
-                  style={{ 
+                <img
+                  src={previewImage}
+                  alt={`${featureName} Preview`}
+                  loading="lazy"
+                  style={{
                     width: '100%', 
                     height: 'auto',
                     display: 'block',
@@ -405,6 +406,7 @@ const UpgradeMessage = ({
                     <img
                       src="/assets/memeSRC-white.svg"
                       alt="memeSRC logo"
+                      loading="lazy"
                       style={{ height: isStacked ? 44 : 48 }}
                     />
                     <Box 

--- a/src/components/floating-action-buttons/FloatingActionButtons.js
+++ b/src/components/floating-action-buttons/FloatingActionButtons.js
@@ -1,7 +1,12 @@
 import { useState, useEffect, useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Fab, Button, styled, Stack, Typography, Box, CardMedia, Divider, Badge } from '@mui/material';
-import { MapsUgc, Favorite, Shuffle, Dashboard, Delete, Edit } from '@mui/icons-material';
+import MapsUgcIcon from '@mui/icons-material/MapsUgc';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import ShuffleIcon from '@mui/icons-material/Shuffle';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
 import LoadingButton from '@mui/lab/LoadingButton';
 import { useNavigate } from 'react-router-dom';
 import useLoadRandomFrame from '../../utils/loadRandomFrame';
@@ -221,7 +226,7 @@ export default function FloatingActionButtons({ shows, showAd }) {
                         <StyledButton 
                             ref={buttonRef}
                             onClick={() => showImageDrawer ? handleClose() : setShowImageDrawer(true)}
-                            startIcon={<Dashboard />} 
+                            startIcon={<DashboardIcon />}
                             variant="contained" 
                             style={{ backgroundColor: "black", zIndex: '1300' }}
                         >
@@ -233,19 +238,19 @@ export default function FloatingActionButtons({ shows, showAd }) {
                     <>
                         <a href="/support" rel="noreferrer" style={{ color: 'white', textDecoration: 'none' }}>
                             <Fab color="primary" aria-label="feedback" style={{ margin: "0 10px 0 0", backgroundColor: "black", zIndex: '1300' }} size='medium'>
-                                <MapsUgc color="white" />
+                                <MapsUgcIcon color="white" />
                             </Fab>
                         </a>
                         <a href="https://memesrc.com/donate" target="_blank" rel="noreferrer" style={{ color: 'white', textDecoration: 'none' }}>
                             <Fab color="primary" aria-label="donate" style={{ backgroundColor: "black", zIndex: '1300' }} size='medium'>
-                                <Favorite />
+                                <FavoriteIcon />
                             </Fab>
                         </a>
                     </>
                 )}
             </StyledLeftFooter>
             <StyledRightFooter className="bottomBtn" hasAd={showAd}>
-                <StyledButton onClick={() => { loadRandomFrame(shows) }} loading={loadingRandom} startIcon={<Shuffle />} variant="contained" style={{ backgroundColor: "black", marginLeft: 'auto', zIndex: '1300' }} >Random</StyledButton>
+                <StyledButton onClick={() => { loadRandomFrame(shows) }} loading={loadingRandom} startIcon={<ShuffleIcon />} variant="contained" style={{ backgroundColor: "black", marginLeft: 'auto', zIndex: '1300' }} >Random</StyledButton>
             </StyledRightFooter>
             
             {hasCollageAccess && (showImageDrawer || isClosing) && (
@@ -330,7 +335,7 @@ export default function FloatingActionButtons({ shows, showAd }) {
                                                             "{item.subtitle}"
                                                         </Typography>
                                                         {item.subtitleShowing && (
-                                                            <Edit 
+                                                            <EditIcon
                                                                 style={{ 
                                                                     color: '#4CAF50', 
                                                                     fontSize: '14px',
@@ -357,7 +362,7 @@ export default function FloatingActionButtons({ shows, showAd }) {
                                                     flexShrink: 0
                                                 }}
                                             >
-                                                <Delete fontSize="small" />
+                                                <DeleteIcon fontSize="small" />
                                             </Button>
                                         </Stack>
                                         
@@ -382,7 +387,7 @@ export default function FloatingActionButtons({ shows, showAd }) {
                                         marginTop: '12px',
                                         fontWeight: 'bold'
                                     }}
-                                    startIcon={<Dashboard />}
+                                    startIcon={<DashboardIcon />}
                                 >
                                     Create Collage ({count} images)
                                 </Button>
@@ -413,7 +418,7 @@ export default function FloatingActionButtons({ shows, showAd }) {
                                             borderColor: 'rgba(255, 255, 255, 0.3)',
                                             marginTop: '8px'
                                         }}
-                                        startIcon={<Delete />}
+                                        startIcon={<DeleteIcon />}
                                     >
                                         Clear All ({count})
                                     </Button>

--- a/src/components/magic-popup/MagicPopup.js
+++ b/src/components/magic-popup/MagicPopup.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import { useContext, useState } from 'react';
 import { Box, Chip, Divider, Fab, Popover, Stack, Typography, useTheme } from '@mui/material';
-import { AutoFixHighRounded, Close } from '@mui/icons-material';
+import AutoFixHighRoundedIcon from '@mui/icons-material/AutoFixHighRounded';
+import CloseIcon from '@mui/icons-material/Close';
 import { LoadingButton } from '@mui/lab';
 import { useNavigate } from 'react-router-dom';
 import { UserContext } from '../../UserContext';
@@ -66,7 +67,7 @@ export default function MagicPopup({ children }) {
                         },
                     }}
                 >
-                    <Close />
+                    <CloseIcon />
                 </Fab>
                 <Box
                     m={3}
@@ -80,7 +81,7 @@ export default function MagicPopup({ children }) {
                         <>
                             <Stack justifyContent="center" spacing={3}>
                                 <Stack direction="row" color="#54d62c" alignItems="center" justifyContent="left" spacing={1}>
-                                    <AutoFixHighRounded fontSize="large" />
+                                    <AutoFixHighRoundedIcon fontSize="large" />
                                     <Typography variant="h3">Magic Tools</Typography>
                                 </Stack>
 
@@ -138,7 +139,7 @@ export default function MagicPopup({ children }) {
                     {user?.userDetails?.magicSubscription === 'true' && (
                         <Stack justifyContent="center" spacing={3}>
                             <Stack direction="row" color="#54d62c" alignItems="center" justifyContent="left" spacing={1}>
-                                <AutoFixHighRounded fontSize="large" />
+                                <AutoFixHighRoundedIcon fontSize="large" />
                                 <Typography variant="h3">Magic Tools</Typography>
                             </Stack>
 
@@ -217,7 +218,7 @@ export default function MagicPopup({ children }) {
                     {/* {(!user?.userDetails?.earlyAccessStatus || user?.userDetails?.earlyAccessStatus === 'requested') && (
                         <Stack justifyContent="center" spacing={3}>
                             <Stack direction="row" color="#54d62c" alignItems="center" justifyContent="left" spacing={1}>
-                                <AutoFixHighRounded fontSize="large" />
+                                <AutoFixHighRoundedIcon fontSize="large" />
                                 <Typography variant="h3">Magic Tools</Typography>
                             </Stack>
 

--- a/src/components/v2-feature-section/sections/editor-updates.js
+++ b/src/components/v2-feature-section/sections/editor-updates.js
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import { Container, Box, Typography, useMediaQuery } from '@mui/material';
-import { PhotoAlbum, OpenWith, Layers, FormatShapes, AutoFixHighRounded } from '@mui/icons-material';
+import PhotoAlbumIcon from '@mui/icons-material/PhotoAlbum';
+import OpenWithIcon from '@mui/icons-material/OpenWith';
+import LayersIcon from '@mui/icons-material/Layers';
+import FormatShapesIcon from '@mui/icons-material/FormatShapes';
+import AutoFixHighRoundedIcon from '@mui/icons-material/AutoFixHighRounded';
 
 export default function EditorUpdates({ backgroundColor, textColor, large }) {
     const isMd = useMediaQuery(theme => theme.breakpoints.up('md'))
@@ -53,7 +57,7 @@ export default function EditorUpdates({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <PhotoAlbum sx={{ color: backgroundColor }} />
+                        <PhotoAlbumIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Edit your own pictures
@@ -72,7 +76,7 @@ export default function EditorUpdates({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <OpenWith sx={{ color: backgroundColor }} />
+                        <OpenWithIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Freeform Placement
@@ -91,7 +95,7 @@ export default function EditorUpdates({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <Layers sx={{ color: backgroundColor }} />
+                        <LayersIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Layers
@@ -110,7 +114,7 @@ export default function EditorUpdates({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <FormatShapes sx={{ color: backgroundColor }} />
+                        <FormatShapesIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Formatting
@@ -129,7 +133,7 @@ export default function EditorUpdates({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <AutoFixHighRounded sx={{ color: backgroundColor }} />
+                        <AutoFixHighRoundedIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Magic Tools

--- a/src/components/v2-feature-section/sections/memesrc-pro.js
+++ b/src/components/v2-feature-section/sections/memesrc-pro.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 import { Container, Box, Typography, useMediaQuery } from '@mui/material';
-import { Bolt, SupportAgent, AutoFixHighRounded, Check } from '@mui/icons-material';
+import BoltIcon from '@mui/icons-material/Bolt';
+import SupportAgentIcon from '@mui/icons-material/SupportAgent';
+import AutoFixHighRoundedIcon from '@mui/icons-material/AutoFixHighRounded';
+import CheckIcon from '@mui/icons-material/Check';
 
 export default function MemeSrcPro({ backgroundColor, textColor, large }) {
     const isMd = useMediaQuery(theme => theme.breakpoints.up('md'))
@@ -52,7 +55,7 @@ export default function MemeSrcPro({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <Check sx={{ color: backgroundColor }} />
+                        <CheckIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         No Ads
@@ -71,7 +74,7 @@ export default function MemeSrcPro({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <SupportAgent sx={{ color: backgroundColor }} />
+                        <SupportAgentIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Pro Support
@@ -90,7 +93,7 @@ export default function MemeSrcPro({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <Bolt sx={{ color: backgroundColor }} />
+                        <BoltIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Early Access Features
@@ -109,7 +112,7 @@ export default function MemeSrcPro({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <AutoFixHighRounded sx={{ color: backgroundColor }} />
+                        <AutoFixHighRoundedIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Magic Tools

--- a/src/components/v2-feature-section/sections/platform-updates.js
+++ b/src/components/v2-feature-section/sections/platform-updates.js
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import { Container, Box, Typography, useMediaQuery } from '@mui/material';
-import { HowToVote, Upload, Science, GitHub, Update } from '@mui/icons-material';
+import HowToVoteIcon from '@mui/icons-material/HowToVote';
+import UploadIcon from '@mui/icons-material/Upload';
+import ScienceIcon from '@mui/icons-material/Science';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import UpdateIcon from '@mui/icons-material/Update';
 
 export default function PlatformUpdates({ backgroundColor, textColor, large }) {
     const isMd = useMediaQuery(theme => theme.breakpoints.up('md'))
@@ -53,7 +57,7 @@ export default function PlatformUpdates({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <HowToVote sx={{ color: backgroundColor }} />
+                        <HowToVoteIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Voting
@@ -72,7 +76,7 @@ export default function PlatformUpdates({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <Upload sx={{ color: backgroundColor }} />
+                        <UploadIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Index Uploads
@@ -91,7 +95,7 @@ export default function PlatformUpdates({ backgroundColor, textColor, large }) {
                             mr: 2,
                         }}
                     >
-                        <Science sx={{ color: backgroundColor }} />
+                        <ScienceIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Early Access
@@ -111,7 +115,7 @@ export default function PlatformUpdates({ backgroundColor, textColor, large }) {
                             aspectRatio: '1/1'
                         }}
                     >
-                        <GitHub sx={{ color: backgroundColor }} />
+                        <GitHubIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Open Source
@@ -131,7 +135,7 @@ export default function PlatformUpdates({ backgroundColor, textColor, large }) {
                             aspectRatio: '1/1'
                         }}
                     >
-                        <Update sx={{ color: backgroundColor }} />
+                        <UpdateIcon sx={{ color: backgroundColor }} />
                     </Box>
                     <Typography fontSize={18} fontWeight={500} sx={{ color: textColor }}>
                         Faster, more resilient, and easier to build upon

--- a/src/contexts/SubscribeDialog.js
+++ b/src/contexts/SubscribeDialog.js
@@ -248,6 +248,7 @@ export const DialogProvider = ({ children }) => {
             <img
               src="/assets/memeSRC-white.svg"
               alt="memeSRC logo"
+              loading="lazy"
               style={{ height: isCompact ? 24 : 36 }}
             />
             <Typography fontSize={isCompact ? 22 : 28} fontWeight={700}>

--- a/src/global.css
+++ b/src/global.css
@@ -1,59 +1,71 @@
 @font-face {
     font-family: 'Akbar';
     src: url('./fonts/akbar.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'Baveuse';
     src: url('./fonts/baveuse.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'Futurama';
     src: url('./fonts/fr-bold.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'HORROR';
     src: url('./fonts/horror.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'IMPACT';
     src: url('./fonts/impact.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'PULPY';
     src: url('./fonts/pulpy.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'scrubs';
     src: url('./fonts/scrubs.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'South Park';
     src: url('./fonts/south-park.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'SPIDEY';
     src: url('./fonts/spidey.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'Star Jedi';
     src: url('./fonts/star-jedi.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'twilight';
     src: url('./fonts/twilight.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'zuume';
     src: url('./fonts/zuume.ttf') format('truetype');
+    font-display: swap;
 }

--- a/src/layouts/dashboard/header/LanguagePopover.js
+++ b/src/layouts/dashboard/header/LanguagePopover.js
@@ -49,7 +49,7 @@ export default function LanguagePopover() {
           }),
         }}
       >
-        <img src={LANGS[0].icon} alt={LANGS[0].label} />
+        <img src={LANGS[0].icon} alt={LANGS[0].label} loading="lazy" />
       </IconButton>
 
       <Popover

--- a/src/layouts/dashboard/header/NotificationsPopover.js
+++ b/src/layouts/dashboard/header/NotificationsPopover.js
@@ -353,30 +353,30 @@ function renderContent(notification) {
 
   if (notification.type === 'order_placed') {
     return {
-      avatar: <img alt={notification.title} src="/assets/icons/ic_notification_package.svg" />,
+      avatar: <img alt={notification.title} src="/assets/icons/ic_notification_package.svg" loading="lazy" />,
       title,
     };
   }
   if (notification.type === 'order_shipped') {
     return {
-      avatar: <img alt={notification.title} src="/assets/icons/ic_notification_shipping.svg" />,
+      avatar: <img alt={notification.title} src="/assets/icons/ic_notification_shipping.svg" loading="lazy" />,
       title,
     };
   }
   if (notification.type === 'mail') {
     return {
-      avatar: <img alt={notification.title} src="/assets/icons/ic_notification_mail.svg" />,
+      avatar: <img alt={notification.title} src="/assets/icons/ic_notification_mail.svg" loading="lazy" />,
       title,
     };
   }
   if (notification.type === 'chat_message') {
     return {
-      avatar: <img alt={notification.title} src="/assets/icons/ic_notification_chat.svg" />,
+      avatar: <img alt={notification.title} src="/assets/icons/ic_notification_chat.svg" loading="lazy" />,
       title,
     };
   }
   return {
-    avatar: notification.avatar ? <img alt={notification.title} src={notification.avatar} /> : null,
+    avatar: notification.avatar ? <img alt={notification.title} src={notification.avatar} loading="lazy" /> : null,
     title,
   };
 }

--- a/src/pages/CollagePageLegacy.js
+++ b/src/pages/CollagePageLegacy.js
@@ -1017,6 +1017,7 @@ export default function CollagePage() {
               <img
                 src="/assets/memeSRC-white.svg"
                 alt="memeSRC logo"
+                loading="lazy"
                 style={{ height: 48, marginBottom: -15 }}
               />
               <Typography variant="h3" textAlign="center">
@@ -1144,7 +1145,7 @@ export default function CollagePage() {
                     <>
                       <ImageContainer ref={(el) => { imageRefs.current[index] = el; }}>
                         <ImageWrapper>
-                          <img src={image.src} alt={`layer ${index + 1}`} style={{ width: "100%" }} />
+                          <img src={image.src} alt={`layer ${index + 1}`} loading="lazy" style={{ width: "100%" }} />
                           <DeleteButton className="delete-button" onClick={() => deleteImage(index)}>
                             <Close />
                           </DeleteButton>

--- a/src/pages/DashboardSeriesPage.js
+++ b/src/pages/DashboardSeriesPage.js
@@ -678,7 +678,7 @@ export default function DashboardSeriesPage() {
                     seriesSeasons.map((season) =>
                       season.type.id === 1 ? (
                         <Grid item xs={6} md={4} key={season.id}>
-                          <img src={season.image} alt="season artwork" style={{ width: '100%', height: 'auto' }} />
+                          <img src={season.image} alt="season artwork" loading="lazy" style={{ width: '100%', height: 'auto' }} />
                           <Typography component="h6" variant="h6">
                             Season {season.number}
                           </Typography>

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -228,7 +228,14 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
 
   // Warm up the UUID function for faster save dialog response
   useEffect(() => {
-    API.get('publicapi', '/uuid', { queryStringParameters: { warmup: true } })
+    const warmup = () => {
+      API.get('publicapi', '/uuid', { queryStringParameters: { warmup: true } })
+    }
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(warmup)
+    } else {
+      setTimeout(warmup, 1000)
+    }
   }, [])
 
   useEffect(() => {
@@ -1934,6 +1941,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                     src={`https://i${process.env.REACT_APP_USER_BRANCH === 'prod' ? 'prod' : `-${process.env.REACT_APP_USER_BRANCH}`
                       }.memesrc.com/${generatedImageFilename}`}
                     alt="generated meme"
+                    loading="lazy"
                   />
                 )}
                 {imageUploading && (
@@ -2049,6 +2057,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                   <img
                     src={image}
                     alt="placeholder"
+                    loading="lazy"
                     style={{
                       width: '100%',
                       aspectRatio: `${editorAspectRatio}/1`,

--- a/src/pages/FacebookAuthDemo.js
+++ b/src/pages/FacebookAuthDemo.js
@@ -164,6 +164,7 @@ export default function FacebookAuthDemo() {
                         <img
                           src={profileInfo.picture.data.url}
                           alt="Profile"
+                          loading="lazy"
                           style={{ width: '100px', height: '100px', borderRadius: '50%', marginBottom: '16px' }}
                         />
                       )}

--- a/src/pages/FavoritesPage.js
+++ b/src/pages/FavoritesPage.js
@@ -177,6 +177,7 @@ const FavoritesPage = () => {
             <img
               src="/assets/memeSRC-white.svg"
               alt="memeSRC logo"
+              loading="lazy"
               style={{ height: 48, marginBottom: -15 }}
             />
             <Typography variant="h3" textAlign="center">

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -30,11 +30,16 @@ export default function SearchPage({ metadata }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Make sure API functions are warm
-    API.get('publicapi', '/search', { queryStringParameters: { warmup: true } })
-    API.get('publicapi', '/random', { queryStringParameters: { warmup: true } })
-    // Prep sessionID for future use
-    prepSessionID()
+    const warmup = () => {
+      API.get('publicapi', '/search', { queryStringParameters: { warmup: true } })
+      API.get('publicapi', '/random', { queryStringParameters: { warmup: true } })
+      prepSessionID()
+    }
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(warmup)
+    } else {
+      setTimeout(warmup, 1000)
+    }
   }, [])
 
   const handleSearch = useCallback((e) => {

--- a/src/pages/ProSupport.js
+++ b/src/pages/ProSupport.js
@@ -114,6 +114,7 @@ export default function ProSupport() {
                 <img
                   src="/assets/memeSRC-white.svg"
                   alt="memeSRC logo"
+                  loading="lazy"
                   style={{ height: 48, marginBottom: -15 }}
                 />
                 <Typography variant="h3" textAlign="center">

--- a/src/pages/SubtitleViewerPage.js
+++ b/src/pages/SubtitleViewerPage.js
@@ -226,11 +226,12 @@ const SubtitleViewerPage = () => {
                 >
                   <TableCell style={{ width: 160 }}>
                     {frameImages[subtitle.middle_frame] && (
-                      <img 
-                        src={frameImages[subtitle.middle_frame]} 
+                      <img
+                        src={frameImages[subtitle.middle_frame]}
                         alt={`Frame ${subtitle.middle_frame}`}
-                        style={{ 
-                          width: '100%', 
+                        loading="lazy"
+                        style={{
+                          width: '100%',
                           height: 'auto',
                           display: loadedImages[subtitle.middle_frame] ? 'block' : 'none',
                           cursor: 'pointer'

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -292,7 +292,14 @@ const EditorPage = ({ shows }) => {
 
   // Warm up the UUID function for faster save dialog response
   useEffect(() => {
-    API.get('publicapi', '/uuid', { queryStringParameters: { warmup: true } })
+    const warmup = () => {
+      API.get('publicapi', '/uuid', { queryStringParameters: { warmup: true } })
+    }
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(warmup)
+    } else {
+      setTimeout(warmup, 1000)
+    }
   }, [])
 
   useEffect(() => {
@@ -2334,6 +2341,7 @@ const EditorPage = ({ shows }) => {
                     src={`https://i${process.env.REACT_APP_USER_BRANCH === 'prod' ? 'prod' : `-${process.env.REACT_APP_USER_BRANCH}`
                       }.memesrc.com/${generatedImageFilename}`}
                     alt="generated meme"
+                    loading="lazy"
                   />
                 )}
                 {imageUploading && (
@@ -2460,6 +2468,7 @@ const EditorPage = ({ shows }) => {
                   <img
                     src={image}
                     alt="placeholder"
+                    loading="lazy"
                     style={{
                       width: '100%',
                       aspectRatio: `${editorAspectRatio}/1`,

--- a/src/pages/VotingPage.js
+++ b/src/pages/VotingPage.js
@@ -1440,6 +1440,7 @@ export default function VotingPage() {
                                       <img
                                         src={show.image || 'path/to/placeholder-image.jpg'}
                                         alt={show.name}
+                                        loading="lazy"
                                         style={{
                                           ...showImageStyle,
                                           display: loadedImages[show.id] ? 'block' : 'none',

--- a/src/sections/@dashboard/series/AddSeries.js
+++ b/src/sections/@dashboard/series/AddSeries.js
@@ -228,7 +228,7 @@ export default function AddSeries() {
             {seriesSeasons && seriesSeasons.map((season) =>
                 (season.type.id === 1) ?
                     <Grid key={season.id || season.number} item xs={6} md={2}>
-                        <img src={season.image} alt='season artwork' style={{ width: '100%', height: 'auto' }} />
+                        <img src={season.image} alt='season artwork' loading="lazy" style={{ width: '100%', height: 'auto' }} />
                         <Typography component='h6' variant='h6'>
                             Season {season.number}
                         </Typography>

--- a/src/utils/adsenseLoader.js
+++ b/src/utils/adsenseLoader.js
@@ -6,28 +6,34 @@ let adsenseLoaded = false;
 
 export const useAdsenseLoader = () => {
   const { user } = useContext(UserContext);
-  
-  useEffect(() => {
-    // Only load AdSense if user is not logged in or doesn't have an active subscription
-    if (!adsenseLoaded && (!user || user?.userDetails?.subscriptionStatus !== 'active')) {
-      const script = document.createElement("script");
-      script.src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1307598869123774";
-      script.async = true;
-      script.crossOrigin = "anonymous";
-      document.body.appendChild(script);
-      adsenseLoaded = true;
 
-      return () => {
-        // Cleanup if user becomes a subscriber
-        if (user?.userDetails?.subscriptionStatus === 'active') {
-          document.body.removeChild(script);
-          adsenseLoaded = false;
-          // Clear any existing ads
-          const ads = document.getElementsByClassName('adsbygoogle');
-          Array.from(ads).forEach(ad => ad.remove());
-        }
+  useEffect(() => {
+    let cleanup;
+    if (!adsenseLoaded && (!user || user?.userDetails?.subscriptionStatus !== 'active')) {
+      const loadAdsense = () => {
+        const script = document.createElement("script");
+        script.src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1307598869123774";
+        script.async = true;
+        script.crossOrigin = "anonymous";
+        document.body.appendChild(script);
+        adsenseLoaded = true;
+
+        return () => {
+          if (user?.userDetails?.subscriptionStatus === 'active') {
+            document.body.removeChild(script);
+            adsenseLoaded = false;
+            const ads = document.getElementsByClassName('adsbygoogle');
+            Array.from(ads).forEach(ad => ad.remove());
+          }
+        };
       };
+
+      if ('requestIdleCallback' in window) {
+        requestIdleCallback(() => { cleanup = loadAdsense(); });
+      } else {
+        setTimeout(() => { cleanup = loadAdsense(); }, 1000);
+      }
     }
-    return undefined; // Explicit return for when conditions aren't met
+    return cleanup;
   }, [user]);
 };


### PR DESCRIPTION
## Summary
- delay warmup API requests until the browser is idle
- load AdSense asynchronously when idle
- add dns-prefetch for the GraphQL API
- switch icon imports to individual modules for better tree shaking

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688556644a74832d8ee7b68f5b3e405d