### PR TITLE
Improve accessibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
 
   <meta name="theme-color" content="#000000" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
 
   <!-- Google Tag Manager -->

--- a/src/components/TextEditorControls.js
+++ b/src/components/TextEditorControls.js
@@ -117,6 +117,7 @@ export default function TextEditorControls(props) {
           size="small"
           color={editorVisible ? 'primary' : 'default'}
           onClick={() => setEditorVisible((prev) => !prev)}
+          aria-label="toggle settings"
           sx={{ marginLeft: 1 }}
         >
           <Settings />

--- a/src/components/TvdbSearch/TvdbSearch.js
+++ b/src/components/TvdbSearch/TvdbSearch.js
@@ -200,11 +200,12 @@ export default function TvdbSearch({ onSelect = () => {}, onClear = () => {}, ty
                 InputProps={{
                     endAdornment:
                         <>
-                            <IconButton disabled={!searchTerm} onClick={handleSearch}>
+                            <IconButton aria-label="search" disabled={!searchTerm} onClick={handleSearch}>
                                 <Search />
                             </IconButton>
                             {searchTerm &&
                                 <IconButton
+                                    aria-label="clear search"
                                     onClick={() => {
                                         setSearchTerm('')
                                         setOptions([])

--- a/src/components/collage/components/CanvasCollagePreview.js
+++ b/src/components/collage/components/CanvasCollagePreview.js
@@ -2941,6 +2941,7 @@ const CanvasCollagePreview = ({
              !isDraggingBorder && !isReorderMode && (
               <IconButton
                 size="small"
+                aria-label={isInTransformMode ? 'finish transform' : 'open actions'}
                 onClick={(e) =>
                   isInTransformMode
                     ? toggleTransformMode(panelId)
@@ -2980,6 +2981,7 @@ const CanvasCollagePreview = ({
             {isReorderMode && reorderSourcePanel === panelId && (
               <IconButton
                 size="small"
+                aria-label="cancel reorder"
                 onClick={cancelReorderMode}
                 sx={{
                   position: 'absolute',

--- a/src/components/collage/components/CollageResultDialog.js
+++ b/src/components/collage/components/CollageResultDialog.js
@@ -151,6 +151,7 @@ export default function CollageResultDialog({ open, onClose, finalImage }) {
         >
           {/* Close Button */}
           <IconButton
+            aria-label="close"
             onClick={onClose}
             sx={{
               position: 'absolute',

--- a/src/components/collage/components/DisclosureCard.js
+++ b/src/components/collage/components/DisclosureCard.js
@@ -157,6 +157,7 @@ const DisclosureCard = ({
         {/* Right side: Expand/Collapse Arrow */}
         <IconButton
           size="small"
+          aria-label="toggle"
           sx={{
             transition: 'transform 0.2s ease',
             transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',

--- a/src/components/homepage-section-forms/ButtonsForm.js
+++ b/src/components/homepage-section-forms/ButtonsForm.js
@@ -66,13 +66,13 @@ export default function ButtonsForm({ buttons, setButtons }) {
                         />
                     </Grid>
                     <Grid item xs={12}>
-                        <IconButton onClick={() => handleRemoveButton(index)}>
+                        <IconButton aria-label="remove button" onClick={() => handleRemoveButton(index)}>
                             <RemoveCircleOutline />
                         </IconButton>
                     </Grid>
                 </Grid>
             )) : "None"}
-            <IconButton onClick={() => handleAddButton()}>
+            <IconButton aria-label="add button" onClick={() => handleAddButton()}>
                 <AddCircleOutline />
             </IconButton>
         </>

--- a/src/components/logo/Logo.js
+++ b/src/components/logo/Logo.js
@@ -70,6 +70,7 @@ const Logo = forwardRef(({ sx, ...other }, ref) => (
     ref={ref}
     component="img"
     src={`/assets/memeSRC${other.color === 'white' ? '-white' : '-color'}.svg`}
+    alt="memeSRC logo"
     sx={{ width: 40, objectFit: 'contain', height: 'auto', cursor: 'pointer', ...sx }}
   />
 ));

--- a/src/layouts/dashboard/header/index.js
+++ b/src/layouts/dashboard/header/index.js
@@ -159,6 +159,7 @@ export default function Header({ onOpenNav }) {
       <StyledToolbar sx={{ position: 'relative', minHeight: { xs: 45, md: '45px !important' } }} ref={containerRef}>
           <IconButton
             onClick={onOpenNav}
+            aria-label="open navigation"
             sx={{
               color: 'text.primary',
               ml: -1,
@@ -335,7 +336,7 @@ export default function Header({ onOpenNav }) {
               >
                 View
               </Button>
-              <IconButton size='small'>
+              <IconButton size='small' aria-label="dismiss alert">
                 <Close />
               </IconButton>
             </Stack>
@@ -369,6 +370,7 @@ export default function Header({ onOpenNav }) {
           </Button>
           <IconButton
             size='small'
+            aria-label="dismiss"
             onClick={() => {
               handleEarlyAccessDismiss()
               setMagicAlertOpen(false)
@@ -414,6 +416,7 @@ export default function Header({ onOpenNav }) {
               <IconButton
                 className="close-button"
                 size="small"
+                aria-label="dismiss"
                 sx={{
                   position: 'absolute',
                   right: 4,

--- a/src/pages/AccountPage.js
+++ b/src/pages/AccountPage.js
@@ -570,6 +570,7 @@ const AccountPage = () => {
                     ).toLocaleDateString()}`}
                   />
                   <IconButton
+                    aria-label="download invoice"
                     onClick={(e) => {
                       e.stopPropagation();
                       downloadInvoicePDF(invoice.invoice_pdf);

--- a/src/pages/CollagePageLegacy.js
+++ b/src/pages/CollagePageLegacy.js
@@ -204,6 +204,7 @@ function TryNewVersionBanner({ user, onTryNewVersion }) {
           <>
             {/* Close button */}
             <IconButton
+              aria-label="close banner"
               onClick={handleDismissClick}
               sx={{
                 position: 'absolute',
@@ -1146,16 +1147,16 @@ export default function CollagePage() {
                       <ImageContainer ref={(el) => { imageRefs.current[index] = el; }}>
                         <ImageWrapper>
                           <img src={image.src} alt={`layer ${index + 1}`} loading="lazy" style={{ width: "100%" }} />
-                          <DeleteButton className="delete-button" onClick={() => deleteImage(index)}>
+                          <DeleteButton aria-label="delete layer" className="delete-button" onClick={() => deleteImage(index)}>
                             <Close />
                           </DeleteButton>
-                          <EditButton className="edit-button" onClick={() => handleEditImage(index)}>
+                          <EditButton aria-label="edit layer" className="edit-button" onClick={() => handleEditImage(index)}>
                             <Edit />
                           </EditButton>
-                          <MoveUpButton className="move-up-button" onClick={() => moveImage(index, -1)}>
+                          <MoveUpButton aria-label="move layer up" className="move-up-button" onClick={() => moveImage(index, -1)}>
                             <ArrowUpward />
                           </MoveUpButton>
-                          <MoveDownButton className="move-down-button" onClick={() => moveImage(index, 1)}>
+                          <MoveDownButton aria-label="move layer down" className="move-down-button" onClick={() => moveImage(index, 1)}>
                             <ArrowDownward />
                           </MoveDownButton>
                         </ImageWrapper>

--- a/src/pages/DashboardAliasPageRevised.js
+++ b/src/pages/DashboardAliasPageRevised.js
@@ -308,13 +308,14 @@ const AliasManagementPageRevised = () => {
                   <TableCell>{alias.aliasV2ContentMetadataId}</TableCell>
                   <TableCell align="right">
                     <IconButton
+                      aria-label="refresh metadata"
                       onClick={() => refreshMetadata(alias.aliasV2ContentMetadataId)}
                       disabled={refreshingMetadata === alias.aliasV2ContentMetadataId}
                     >
                       {refreshingMetadata === alias.aliasV2ContentMetadataId ? <CircularProgress size={24} /> : <Refresh />}
                     </IconButton>
-                    <IconButton onClick={() => handleOpenDialog(alias)}><Edit /></IconButton>
-                    <IconButton onClick={() => handleOpenDeleteDialog(alias)} color="error"><Delete /></IconButton>
+                    <IconButton aria-label="edit alias" onClick={() => handleOpenDialog(alias)}><Edit /></IconButton>
+                    <IconButton aria-label="delete alias" onClick={() => handleOpenDeleteDialog(alias)} color="error"><Delete /></IconButton>
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -1290,10 +1290,10 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                     <Stack direction='row' width='100%' justifyContent='space-between' alignItems='center'>
 
                       <ButtonGroup variant="contained" size="small">
-                        <IconButton disabled={(editorStates.length <= 1)} onClick={undo}>
+                        <IconButton aria-label="undo" disabled={(editorStates.length <= 1)} onClick={undo}>
                           <UndoIcon />
                         </IconButton>
-                        <IconButton disabled={(futureStates.length === 0)} onClick={redo}>
+                        <IconButton aria-label="redo" disabled={(futureStates.length === 0)} onClick={redo}>
                           <RedoIcon />
                         </IconButton>
                       </ButtonGroup>

--- a/src/pages/ErrorPage.js
+++ b/src/pages/ErrorPage.js
@@ -38,6 +38,7 @@ export default function ErrorPage() {
           <Box
             component="img"
             src="/assets/memeSRC-color.svg"
+            alt="memeSRC logo"
             sx={{ height: 260, mx: 'auto', my: { xs: 5, sm: 10 } }}
           />
 

--- a/src/pages/Page404.js
+++ b/src/pages/Page404.js
@@ -39,6 +39,7 @@ export default function Page404() {
           <Box
             component="img"
             src="/assets/illustrations/illustration_404.svg"
+            alt="404 not found"
             sx={{ height: 260, mx: 'auto', my: { xs: 5, sm: 10 } }}
           />
 

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -473,7 +473,7 @@ export default function UserPage() {
                       <TableCell align="left">{createdAt}</TableCell>
 
                       <TableCell align="right">
-                        <IconButton size="large" color="inherit" onClick={(event) => {
+                        <IconButton aria-label="open actions" size="large" color="inherit" onClick={(event) => {
                           setChosenUser(row)
                           handleOpenMenu(event, index)
                         }}>

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -1617,10 +1617,10 @@ const EditorPage = ({ shows }) => {
                     <Stack direction='column' width='100%' spacing={1}>
                       <Stack direction='row' width='100%' justifyContent='space-between' alignItems='center'>
                         <ButtonGroup variant="contained" size="small">
-                          <IconButton disabled={(editorStates.length <= 1)} onClick={undo}>
+                          <IconButton aria-label="undo" disabled={(editorStates.length <= 1)} onClick={undo}>
                             <Undo />
                           </IconButton>
-                          <IconButton disabled={(futureStates.length === 0)} onClick={redo}>
+                          <IconButton aria-label="redo" disabled={(futureStates.length === 0)} onClick={redo}>
                             <Redo />
                           </IconButton>
                         </ButtonGroup>
@@ -1661,7 +1661,7 @@ const EditorPage = ({ shows }) => {
                             sx={{ flexGrow: 1, zIndex: 100 }}
                             valueLabelFormat={(value) => `${Math.round(value)}%`}
                           />
-                          <IconButton onClick={toggleWhiteSpaceSlider}>
+                          <IconButton aria-label="close" onClick={toggleWhiteSpaceSlider}>
                             <Close />
                           </IconButton>
                         </Stack>

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -724,6 +724,7 @@ useEffect(() => {
             </div>
           )}
           <IconButton
+            aria-label="previous frames"
             style={{
               position: 'absolute',
               top: '50%',
@@ -741,6 +742,7 @@ useEffect(() => {
             <ArrowBackIos style={{ fontSize: '2rem' }} />
           </IconButton>
           <IconButton
+            aria-label="next frames"
             disabled={Number(frame) - 1 === 0}
             style={{
               position: 'absolute',
@@ -763,7 +765,7 @@ useEffect(() => {
         {frames && frames?.length > 0 ?
           <Stack spacing={2} direction="row" p={0} pr={3} pl={3} alignItems={'center'}>
             <Tooltip title="Fine Tuning">
-              <IconButton>
+              <IconButton aria-label="fine tuning options">
                 {loadingFineTuning ? (
                   <CircularProgress size={24} />
                 ) : (
@@ -812,7 +814,7 @@ useEffect(() => {
           :
           <Stack spacing={2} direction="row" p={0} pr={3} pl={3} alignItems={'center'}>
             <Tooltip title="Fine Tuning">
-              <IconButton>
+              <IconButton aria-label="fine tuning options">
                 <HistoryToggleOffRounded alt="Fine Tuning" />
               </IconButton>
             </Tooltip>

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -200,7 +200,8 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
                 <Box
                   component="img"
                   src={Logo({ color: currentThemeFontColor || 'white' })}
-                  sx={{ 
+                  alt="memeSRC logo"
+                  sx={{
                     objectFit: 'contain', 
                     cursor: 'pointer', 
                     display: 'block', 


### PR DESCRIPTION
## Summary
- allow zooming by adjusting viewport meta tag
- add alt text to logo and error pages
- label various icon buttons for screen readers
- fix accessible names on more pages like advanced editor, frame page, and collage pages

## Testing
- `npm run lint`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68864390b3e8832dbc231b5d6cecc210