### PR TITLE
Improve accessibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
 
   <meta name="theme-color" content="#000000" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
 
   <!-- Google Tag Manager -->

--- a/src/components/collage/components/DisclosureCard.js
+++ b/src/components/collage/components/DisclosureCard.js
@@ -157,6 +157,7 @@ const DisclosureCard = ({
         {/* Right side: Expand/Collapse Arrow */}
         <IconButton
           size="small"
+          aria-label="toggle section"
           sx={{
             transition: 'transform 0.2s ease',
             transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',

--- a/src/components/logo/Logo.js
+++ b/src/components/logo/Logo.js
@@ -70,6 +70,7 @@ const Logo = forwardRef(({ sx, ...other }, ref) => (
     ref={ref}
     component="img"
     src={`/assets/memeSRC${other.color === 'white' ? '-white' : '-color'}.svg`}
+    alt="memeSRC logo"
     sx={{ width: 40, objectFit: 'contain', height: 'auto', cursor: 'pointer', ...sx }}
   />
 ));

--- a/src/contexts/SubscribeDialog.js
+++ b/src/contexts/SubscribeDialog.js
@@ -263,14 +263,15 @@ export const DialogProvider = ({ children }) => {
               memeSRC Pro
             </Typography>
           </Box>
-          <IconButton 
-            onClick={closeDialog} 
-            size="small" 
-            sx={{ 
-              position: 'absolute', 
-              top: isCompact ? 4 : 8, 
-              right: 10, 
-              zIndex: 1000, 
+          <IconButton
+            onClick={closeDialog}
+            size="small"
+            aria-label="close"
+            sx={{
+              position: 'absolute',
+              top: isCompact ? 4 : 8,
+              right: 10,
+              zIndex: 1000,
               opacity: 0.4 
             }}
           >

--- a/src/layouts/dashboard/header/AccountPopover.js
+++ b/src/layouts/dashboard/header/AccountPopover.js
@@ -55,6 +55,7 @@ export default function AccountPopover() {
       {userDetails?.user &&
         <IconButton
           onClick={handleOpen}
+          aria-label="account options"
           sx={{
             p: 0.5,
             width: 44,
@@ -86,6 +87,7 @@ export default function AccountPopover() {
       {!(userDetails?.user) &&
         <IconButton
           onClick={handleOpen}
+          aria-label="account options"
           sx={{
             p: 0.5,
             width: 44,

--- a/src/layouts/dashboard/header/LanguagePopover.js
+++ b/src/layouts/dashboard/header/LanguagePopover.js
@@ -40,6 +40,7 @@ export default function LanguagePopover() {
     <>
       <IconButton
         onClick={handleOpen}
+        aria-label="language"
         sx={{
           padding: 0,
           width: 44,

--- a/src/layouts/dashboard/header/NotificationsPopover.js
+++ b/src/layouts/dashboard/header/NotificationsPopover.js
@@ -182,7 +182,11 @@ export default function NotificationsPopover() {
 
   return (
     <>
-      <IconButton color={open ? 'primary' : 'default'} onClick={handleOpen} sx={{ width: 40, height: 40 }}>
+      <IconButton
+        color={open ? 'primary' : 'default'}
+        onClick={handleOpen}
+        aria-label="notifications"
+        sx={{ width: 40, height: 40 }}>
         <Badge badgeContent={totalUnRead} color="error">
           <Iconify icon="eva:bell-fill" />
         </Badge>

--- a/src/layouts/dashboard/header/Searchbar.js
+++ b/src/layouts/dashboard/header/Searchbar.js
@@ -47,7 +47,7 @@ export default function Searchbar() {
     <ClickAwayListener onClickAway={handleClose}>
       <div>
         {!open && (
-          <IconButton onClick={handleOpen}>
+          <IconButton onClick={handleOpen} aria-label="search">
             <Iconify icon="eva:search-fill" />
           </IconButton>
         )}

--- a/src/layouts/dashboard/header/index.js
+++ b/src/layouts/dashboard/header/index.js
@@ -159,6 +159,7 @@ export default function Header({ onOpenNav }) {
       <StyledToolbar sx={{ position: 'relative', minHeight: { xs: 45, md: '45px !important' } }} ref={containerRef}>
           <IconButton
             onClick={onOpenNav}
+            aria-label="open navigation"
             sx={{
               color: 'text.primary',
               ml: -1,
@@ -369,6 +370,7 @@ export default function Header({ onOpenNav }) {
           </Button>
           <IconButton
             size='small'
+            aria-label='dismiss early access'
             onClick={() => {
               handleEarlyAccessDismiss()
               setMagicAlertOpen(false)
@@ -414,6 +416,7 @@ export default function Header({ onOpenNav }) {
               <IconButton
                 className="close-button"
                 size="small"
+                aria-label="close"
                 sx={{
                   position: 'absolute',
                   right: 4,

--- a/src/layouts/dashboard/nav/index.js
+++ b/src/layouts/dashboard/nav/index.js
@@ -87,6 +87,7 @@ export default function Nav({ openNav, onCloseNav }) {
           <Box
             component="img"
             src="/assets/illustrations/illustration_avatar.png"
+            alt="illustration avatar"
             sx={{ width: 100, position: 'absolute', top: -50 }}
           />
 

--- a/src/pages/CollagePageLegacy.js
+++ b/src/pages/CollagePageLegacy.js
@@ -205,6 +205,7 @@ function TryNewVersionBanner({ user, onTryNewVersion }) {
             {/* Close button */}
             <IconButton
               onClick={handleDismissClick}
+              aria-label="dismiss notice"
               sx={{
                 position: 'absolute',
                 top: 8,
@@ -1121,6 +1122,7 @@ export default function CollagePage() {
                     component="label"
                     sx={{ marginTop: '16px', marginBottom: '16px' }}
                     onClick={(event) => handleMenuClick(event, 0)}
+                    aria-label="add image or text"
                   >
                     <Add />
                   </UploadButton>
@@ -1146,16 +1148,32 @@ export default function CollagePage() {
                       <ImageContainer ref={(el) => { imageRefs.current[index] = el; }}>
                         <ImageWrapper>
                           <img src={image.src} alt={`layer ${index + 1}`} loading="lazy" style={{ width: "100%" }} />
-                          <DeleteButton className="delete-button" onClick={() => deleteImage(index)}>
+                          <DeleteButton
+                            className="delete-button"
+                            onClick={() => deleteImage(index)}
+                            aria-label="delete layer"
+                          >
                             <Close />
                           </DeleteButton>
-                          <EditButton className="edit-button" onClick={() => handleEditImage(index)}>
+                          <EditButton
+                            className="edit-button"
+                            onClick={() => handleEditImage(index)}
+                            aria-label="edit layer"
+                          >
                             <Edit />
                           </EditButton>
-                          <MoveUpButton className="move-up-button" onClick={() => moveImage(index, -1)}>
+                          <MoveUpButton
+                            className="move-up-button"
+                            onClick={() => moveImage(index, -1)}
+                            aria-label="move layer up"
+                          >
                             <ArrowUpward />
                           </MoveUpButton>
-                          <MoveDownButton className="move-down-button" onClick={() => moveImage(index, 1)}>
+                          <MoveDownButton
+                            className="move-down-button"
+                            onClick={() => moveImage(index, 1)}
+                            aria-label="move layer down"
+                          >
                             <ArrowDownward />
                           </MoveDownButton>
                         </ImageWrapper>
@@ -1196,6 +1214,7 @@ export default function CollagePage() {
                     size="small"
                     component="label"
                     onClick={(event) => handleMenuClick(event, images.length)}
+                    aria-label="add image or text"
                   >
                     <Add />
                   </UploadButton>

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -1290,10 +1290,18 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                     <Stack direction='row' width='100%' justifyContent='space-between' alignItems='center'>
 
                       <ButtonGroup variant="contained" size="small">
-                        <IconButton disabled={(editorStates.length <= 1)} onClick={undo}>
+                        <IconButton
+                          disabled={(editorStates.length <= 1)}
+                          onClick={undo}
+                          aria-label="undo"
+                        >
                           <UndoIcon />
                         </IconButton>
-                        <IconButton disabled={(futureStates.length === 0)} onClick={redo}>
+                        <IconButton
+                          disabled={(futureStates.length === 0)}
+                          onClick={redo}
+                          aria-label="redo"
+                        >
                           <RedoIcon />
                         </IconButton>
                       </ButtonGroup>

--- a/src/pages/ErrorPage.js
+++ b/src/pages/ErrorPage.js
@@ -38,6 +38,7 @@ export default function ErrorPage() {
           <Box
             component="img"
             src="/assets/memeSRC-color.svg"
+            alt="memeSRC logo"
             sx={{ height: 260, mx: 'auto', my: { xs: 5, sm: 10 } }}
           />
 

--- a/src/pages/Page404.js
+++ b/src/pages/Page404.js
@@ -39,6 +39,7 @@ export default function Page404() {
           <Box
             component="img"
             src="/assets/illustrations/illustration_404.svg"
+            alt="404 illustration"
             sx={{ height: 260, mx: 'auto', my: { xs: 5, sm: 10 } }}
           />
 

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -1617,10 +1617,18 @@ const EditorPage = ({ shows }) => {
                     <Stack direction='column' width='100%' spacing={1}>
                       <Stack direction='row' width='100%' justifyContent='space-between' alignItems='center'>
                         <ButtonGroup variant="contained" size="small">
-                          <IconButton disabled={(editorStates.length <= 1)} onClick={undo}>
+                          <IconButton
+                            disabled={(editorStates.length <= 1)}
+                            onClick={undo}
+                            aria-label="undo"
+                          >
                             <Undo />
                           </IconButton>
-                          <IconButton disabled={(futureStates.length === 0)} onClick={redo}>
+                          <IconButton
+                            disabled={(futureStates.length === 0)}
+                            onClick={redo}
+                            aria-label="redo"
+                          >
                             <Redo />
                           </IconButton>
                         </ButtonGroup>
@@ -1661,7 +1669,7 @@ const EditorPage = ({ shows }) => {
                             sx={{ flexGrow: 1, zIndex: 100 }}
                             valueLabelFormat={(value) => `${Math.round(value)}%`}
                           />
-                          <IconButton onClick={toggleWhiteSpaceSlider}>
+                          <IconButton onClick={toggleWhiteSpaceSlider} aria-label="close">
                             <Close />
                           </IconButton>
                         </Stack>

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -724,6 +724,7 @@ useEffect(() => {
             </div>
           )}
           <IconButton
+            aria-label="previous frame"
             style={{
               position: 'absolute',
               top: '50%',
@@ -741,6 +742,7 @@ useEffect(() => {
             <ArrowBackIos style={{ fontSize: '2rem' }} />
           </IconButton>
           <IconButton
+            aria-label="next frame"
             disabled={Number(frame) - 1 === 0}
             style={{
               position: 'absolute',
@@ -763,7 +765,7 @@ useEffect(() => {
         {frames && frames?.length > 0 ?
           <Stack spacing={2} direction="row" p={0} pr={3} pl={3} alignItems={'center'}>
             <Tooltip title="Fine Tuning">
-              <IconButton>
+              <IconButton aria-label="fine tuning">
                 {loadingFineTuning ? (
                   <CircularProgress size={24} />
                 ) : (
@@ -812,7 +814,7 @@ useEffect(() => {
           :
           <Stack spacing={2} direction="row" p={0} pr={3} pl={3} alignItems={'center'}>
             <Tooltip title="Fine Tuning">
-              <IconButton>
+              <IconButton aria-label="fine tuning">
                 <HistoryToggleOffRounded alt="Fine Tuning" />
               </IconButton>
             </Tooltip>

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -200,11 +200,12 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
                 <Box
                   component="img"
                   src={Logo({ color: currentThemeFontColor || 'white' })}
-                  sx={{ 
-                    objectFit: 'contain', 
-                    cursor: 'pointer', 
-                    display: 'block', 
-                    width: '130px', 
+                  alt="memeSRC logo"
+                  sx={{
+                    objectFit: 'contain',
+                    cursor: 'pointer',
+                    display: 'block',
+                    width: '130px',
                     height: 'auto',
                     margin: '0 auto',
                     color: 'yellow' 
@@ -352,7 +353,7 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
             </Grid>
           </StyledSearchForm>
           <Grid item xs={12} textAlign="center" color={currentThemeFontColor} marginBottom={2} marginTop={1}>
-            <Typography component="h4" variant="h4">
+            <Typography component="h2" variant="h4">
               {currentThemeBragText}
             </Typography>
           </Grid>


### PR DESCRIPTION
## Summary
- add aria-labels to unlabeled IconButtons used in editor, frame, and collage pages
- provide accessible toggle button in DisclosureCard
- allow upload buttons and collage controls to be properly announced

## Testing
- `npm run lint`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688643a13258832d84402254cc00312f