### PR TITLE
Fix SEO issues with alt text and anchors

### DIFF
--- a/src/components/logo/Logo.js
+++ b/src/components/logo/Logo.js
@@ -70,6 +70,7 @@ const Logo = forwardRef(({ sx, ...other }, ref) => (
     ref={ref}
     component="img"
     src={`/assets/memeSRC${other.color === 'white' ? '-white' : '-color'}.svg`}
+    alt="memeSRC logo"
     sx={{ width: 40, objectFit: 'contain', height: 'auto', cursor: 'pointer', ...sx }}
   />
 ));

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -1831,7 +1831,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
               {surroundingFrames &&
                 surroundingFrames.map((result) => (
                   <Grid item xs={4} sm={4} md={12 / 9} key={result.fid}>
-                    <a style={{ textDecoration: 'none' }}>
+                    <Box component="div" sx={{ textDecoration: 'none' }}>
                       <StyledCard style={{ border: fid === result?.fid ? '3px solid orange' : '' }}>
                         {/* {console.log(`${fid} = ${result?.fid}`)} */}
                         <StyledCardMedia
@@ -1847,7 +1847,7 @@ const EditorPage = ({ setSeriesTitle, shows }) => {
                           }}
                         />
                       </StyledCard>
-                    </a>
+                    </Box>
                   </Grid>
                 ))}
               <Grid item xs={12}>

--- a/src/pages/ErrorPage.js
+++ b/src/pages/ErrorPage.js
@@ -38,6 +38,7 @@ export default function ErrorPage() {
           <Box
             component="img"
             src="/assets/memeSRC-color.svg"
+            alt="memeSRC color logo"
             sx={{ height: 260, mx: 'auto', my: { xs: 5, sm: 10 } }}
           />
 

--- a/src/pages/Page404.js
+++ b/src/pages/Page404.js
@@ -39,6 +39,7 @@ export default function Page404() {
           <Box
             component="img"
             src="/assets/illustrations/illustration_404.svg"
+            alt="404 error illustration"
             sx={{ height: 260, mx: 'auto', my: { xs: 5, sm: 10 } }}
           />
 

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -2217,7 +2217,7 @@ const EditorPage = ({ shows }) => {
                 <Grid item xs={4} sm={4} md={12 / 9} key={`surrounding-frame-${surroundingFrame?.frame ? surroundingFrame?.frame : index}`}>
                   {surroundingFrame !== 'loading' ? (
                     // Render the actual content if the surrounding frame data is available
-                    <a style={{ textDecoration: 'none' }}>
+                    <Box component="div" sx={{ textDecoration: 'none' }}>
                       <StyledCard
                         sx={{
                           ...((parseInt(frame, 10) === surroundingFrame.frame) && { border: '3px solid orange' }),
@@ -2233,7 +2233,7 @@ const EditorPage = ({ shows }) => {
                           }}
                         />
                       </StyledCard>
-                    </a>
+                    </Box>
                   ) : (
                     // Render a skeleton if the data is not yet available (undefined)
                     <Skeleton variant='rounded' sx={{ width: '100%', height: 'auto', aspectRatio: `${editorAspectRatio === 1 ? (16 / 9) : editorAspectRatio}/1` }} />

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -1514,7 +1514,7 @@ useEffect(() => {
                 <Grid item xs={4} sm={4} md={12 / 9} key={`surrounding-frame-${index}`}>
                   {surroundingFrame !== 'loading' ? (
                     // Render the actual content if the surrounding frame data is available
-                    <a style={{ textDecoration: 'none' }}>
+                    <Box component="div" sx={{ textDecoration: 'none' }}>
                       <StyledCard
                         sx={{
                           ...((parseInt(frame, 10) === surroundingFrame.frame) && { border: '3px solid orange' }),
@@ -1541,7 +1541,7 @@ useEffect(() => {
                           <Skeleton variant='rounded' sx={{ width: '100%', height: 0, paddingTop: '56.25%' }} />
                         )}
                       </StyledCard>
-                    </a>
+                    </Box>
                   ) : (
                     // Render a skeleton if the data is not yet available (loading)
                     <Skeleton variant='rounded' sx={{ width: '100%', height: 0, paddingTop: '56.25%' }} />

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -200,14 +200,15 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
                 <Box
                   component="img"
                   src={Logo({ color: currentThemeFontColor || 'white' })}
-                  sx={{ 
-                    objectFit: 'contain', 
-                    cursor: 'pointer', 
-                    display: 'block', 
-                    width: '130px', 
+                  alt="memeSRC logo"
+                  sx={{
+                    objectFit: 'contain',
+                    cursor: 'pointer',
+                    display: 'block',
+                    width: '130px',
                     height: 'auto',
                     margin: '0 auto',
-                    color: 'yellow' 
+                    color: 'yellow'
                   }}
                 />
               </Box>


### PR DESCRIPTION
## Summary
- add alt attributes for site logo images
- remove anchor tags without hrefs in frame and editor pages
- improve alt text for error page illustrations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688643ca9748832d88ff5d73a31ca183