### PR TITLE
Optimize homepage LCP

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,8 @@
 <head>
   <meta charset="utf-8" />
   <link rel="preconnect" href="https://faqco2xj5vc27o7qyuw6uhcyxq.appsync-api.us-east-1.amazonaws.com" crossorigin />
+  <!-- Preload logo for faster Largest Contentful Paint -->
+  <link rel="preload" href="%PUBLIC_URL%/assets/memeSRC-white.svg" as="image" fetchpriority="high" />
   <!-- Favicon -->
   <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/favicon/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon/favicon-32x32.png">

--- a/src/components/logo/Logo.js
+++ b/src/components/logo/Logo.js
@@ -17,6 +17,11 @@ const Logo = forwardRef(({ sx, color = 'white', ...other }, ref) => {
         component="img"
         src="/assets/memeSRC-white.svg"
         alt="memeSRC logo"
+        loading="eager"
+        decoding="async"
+        fetchpriority="high"
+        width={40}
+        height={24}
         sx={{ width: 40, objectFit: 'contain', height: 'auto', cursor: 'pointer', ...sx }}
         {...other}
       />
@@ -32,6 +37,8 @@ const Logo = forwardRef(({ sx, color = 'white', ...other }, ref) => {
       component="svg"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 750 450"
+      width={40}
+      height={24}
       role="img"
       aria-label="memeSRC logo"
       sx={{ width: 40, objectFit: 'contain', height: 'auto', cursor: 'pointer', ...sx }}

--- a/src/global.css
+++ b/src/global.css
@@ -1,59 +1,71 @@
 @font-face {
     font-family: 'Akbar';
     src: url('./fonts/akbar.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'Baveuse';
     src: url('./fonts/baveuse.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'Futurama';
     src: url('./fonts/fr-bold.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'HORROR';
     src: url('./fonts/horror.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'IMPACT';
     src: url('./fonts/impact.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'PULPY';
     src: url('./fonts/pulpy.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'scrubs';
     src: url('./fonts/scrubs.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'South Park';
     src: url('./fonts/south-park.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'SPIDEY';
     src: url('./fonts/spidey.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'Star Jedi';
     src: url('./fonts/star-jedi.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'twilight';
     src: url('./fonts/twilight.ttf') format('truetype');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'zuume';
     src: url('./fonts/zuume.ttf') format('truetype');
+    font-display: swap;
 }


### PR DESCRIPTION
## Summary
- preload the logo for faster Largest Contentful Paint
- set logo fetch priority and dimensions
- avoid font blocking by using `font-display: swap`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68868c1a5ac4832d8fef9d2784f52243