### PR TITLE
Fix missing MUI import

### DIFF
--- a/src/sections/legal/PrivacyPolicy.js
+++ b/src/sections/legal/PrivacyPolicy.js
@@ -1,5 +1,5 @@
 import Container from '@mui/material/Container';
-import styled from '@mui/material/styled';
+import { styled } from '@mui/material/styles';
 import { Helmet } from "react-helmet-async";
 import { Link } from "react-router-dom";
 import Logo from "../../components/logo/Logo";

--- a/src/sections/legal/TermsOfService.js
+++ b/src/sections/legal/TermsOfService.js
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import Logo from '../../components/logo/Logo';
+import { styled } from '@mui/material/styles';
 
 const StyledRoot = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('md')]: {


### PR DESCRIPTION
## Summary
- import `styled` from the correct MUI package in PrivacyPolicy
- add missing `styled` import to TermsOfService

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build` *(fails: Module not found: Can't resolve './aws-exports')*

------
https://chatgpt.com/codex/tasks/task_e_68869ab66ff0832d88b423853c7842df