### PR TITLE
Fix FloatingActionButtons re-renders

### DIFF
--- a/src/components/floating-action-buttons/FloatingActionButtons.js
+++ b/src/components/floating-action-buttons/FloatingActionButtons.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useContext } from 'react';
+import React, { useState, useEffect, useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Fab, Button, styled, Stack, Typography, Box, CardMedia, Divider, Badge } from '@mui/material';
 import { MapsUgc, Favorite, Shuffle, Dashboard, Delete, Edit } from '@mui/icons-material';
@@ -107,7 +107,7 @@ const getImageUrl = (item) => {
     return `https://v2-${process.env.REACT_APP_USER_BRANCH}.memesrc.com/frame/${item.cid}/${item.season}/${item.episode}/${item.frame}`;
 };
 
-export default function FloatingActionButtons({ shows, showAd }) {
+function FloatingActionButtons({ shows, showAd }) {
     const { loadRandomFrame, loadingRandom } = useLoadRandomFrame();
     const { collageItems, clearAll, removeItem, count } = useCollage();
     const [showImageDrawer, setShowImageDrawer] = useState(false);
@@ -120,7 +120,6 @@ export default function FloatingActionButtons({ shows, showAd }) {
     // Check if user is an admin
     const hasCollageAccess = user?.['cognito:groups']?.includes('admins');
 
-    console.log('showImageDrawer:', showImageDrawer, 'collageItems.length:', collageItems.length);
 
     // Function to handle closing with animation
     const handleClose = () => {
@@ -135,7 +134,6 @@ export default function FloatingActionButtons({ shows, showAd }) {
     const handleCreateCollage = () => {
         if (collageItems.length === 0) return;
         
-        console.log('[COLLAGE DEBUG] Original collage items:', collageItems);
         
         // Transform collage items into format expected by collage system
         const collageImages = collageItems.map(item => ({
@@ -152,7 +150,6 @@ export default function FloatingActionButtons({ shows, showAd }) {
             }
         }));
 
-        console.log('[COLLAGE DEBUG] Transformed collage images:', collageImages);
 
         // Navigate to collage page with images
         navigate('/collage', { 
@@ -431,3 +428,5 @@ FloatingActionButtons.propTypes = {
     shows: PropTypes.array.isRequired,
     showAd: PropTypes.bool.isRequired,
 }
+
+export default React.memo(FloatingActionButtons);

--- a/src/contexts/CollageContext.js
+++ b/src/contexts/CollageContext.js
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 const CollageContext = createContext();
@@ -86,14 +86,14 @@ export const CollageProvider = ({ children }) => {
       item.frame === frame
     ), [collageItems]);
 
-  const value = {
+  const value = useMemo(() => ({
     collageItems,
     addItem,
     removeItem,
     clearAll,
     isItemInCollage,
     count: collageItems.length
-  };
+  }), [collageItems, addItem, removeItem, clearAll, isItemInCollage]);
 
   return (
     <CollageContext.Provider value={value}>


### PR DESCRIPTION
## Summary
- memoize the collage context value to avoid unnecessary rerenders
- wrap FloatingActionButtons with `React.memo`
- drop leftover collage debug logs

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887c47318f8832daaea7cf28e19e668