### PR TITLE
Restrict My Library feature to admins

### DIFF
--- a/src/components/collage/components/BulkUploadSection.js
+++ b/src/components/collage/components/BulkUploadSection.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { 
   Box, 
@@ -21,6 +21,7 @@ import {
   Clear
 } from '@mui/icons-material';
 import MyLibrary from './MyLibrary';
+import { UserContext } from '../../../UserContext';
 
 const DEBUG_MODE = process.env.NODE_ENV === 'development';
 const debugLog = (...args) => { if (DEBUG_MODE) console.log(...args); };
@@ -119,6 +120,8 @@ const BulkUploadSection = ({
   libraryRefreshTrigger, // For refreshing library when new images are auto-saved
 }) => {
   const theme = useTheme();
+  const { user } = useContext(UserContext);
+  const isAdmin = user?.['cognito:groups']?.includes('admins');
   const bulkFileInputRef = useRef(null);
   const panelScrollerRef = useRef(null);
   const specificPanelFileInputRef = useRef(null);
@@ -874,7 +877,9 @@ const BulkUploadSection = ({
       )}
 
       {/* User image library below uploader */}
-      <MyLibrary onSelect={handleLibrarySelect} refreshTrigger={libraryRefreshTrigger} />
+      {isAdmin && (
+        <MyLibrary onSelect={handleLibrarySelect} refreshTrigger={libraryRefreshTrigger} />
+      )}
 
       {/* Toast Notification */}
       <Snackbar

--- a/src/components/collage/hooks/useCollageState.js
+++ b/src/components/collage/hooks/useCollageState.js
@@ -8,7 +8,7 @@ const DEBUG_MODE = process.env.NODE_ENV === 'development';
 /**
  * Custom hook to manage collage state
  */
-export const useCollageState = () => {
+export const useCollageState = (isAdmin = false) => {
   // selectedImages now stores: { originalUrl: string, displayUrl: string, subtitle?: string, subtitleShowing?: boolean, metadata?: object }[]
   const [selectedImages, setSelectedImages] = useState([]);
   // panelImageMapping still maps: { panelId: imageIndex }
@@ -27,7 +27,7 @@ export const useCollageState = () => {
   });
   
   // State for auto-saving images to library
-  const [autoSaveToLibrary, setAutoSaveToLibrary] = useState(true);
+  const [autoSaveToLibrary, setAutoSaveToLibrary] = useState(isAdmin);
   const [libraryRefreshTrigger, setLibraryRefreshTrigger] = useState(null);
   
   // Track image data URLs that have been saved to prevent duplicates
@@ -198,7 +198,7 @@ export const useCollageState = () => {
    * Save image to library if auto-save is enabled
    */
   const saveToLibraryIfEnabled = useCallback(async (imageUrl, metadata = {}) => {
-    if (!autoSaveToLibrary || !imageUrl) return;
+    if (!isAdmin || !autoSaveToLibrary || !imageUrl) return;
     
     try {
       // Skip saving if image is from library (prevents duplicates)
@@ -230,7 +230,7 @@ export const useCollageState = () => {
     } catch (error) {
       console.error("❌ Failed to auto-save image to library:", error);
     }
-  }, [autoSaveToLibrary]);
+  }, [autoSaveToLibrary, isAdmin]);
 
   /**
    * Add a new image to the collection.

--- a/src/components/collage/steps/CollageSettingsStep.js
+++ b/src/components/collage/steps/CollageSettingsStep.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars, react/prop-types */
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useContext } from "react";
 import { useTheme, styled, alpha } from "@mui/material/styles";
 import {
   Box,
@@ -32,6 +32,7 @@ import {
   Colorize,
   PhotoLibrary
 } from "@mui/icons-material";
+import { UserContext } from "../../../UserContext";
 
 // Import styled components
 import { TemplateCard } from "../styled/CollageStyled";
@@ -311,7 +312,7 @@ const isDarkColor = (hexColor) => {
 };
 
 // Renamed component to CollageLayoutSettings
-const CollageLayoutSettings = ({ 
+const CollageLayoutSettings = ({
   selectedImages, 
   selectedTemplate, 
   setSelectedTemplate, 
@@ -350,6 +351,8 @@ const CollageLayoutSettings = ({
   // Theme and responsive helpers
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const { user } = useContext(UserContext);
+  const isAdmin = user?.['cognito:groups']?.includes('admins');
   
   // Get aspect ratio value based on selected preset
   const getAspectRatioValue = () => {
@@ -1081,6 +1084,7 @@ const CollageLayoutSettings = ({
       </Box>
       
       {/* Auto-Save to Library Toggle */}
+      {isAdmin && (
       <Box sx={{ mb: isMobile ? 1 : 1.5 }}>
         <StepSectionHeading sx={{ mb: 0.5 }}>
           <PhotoLibrary sx={{ mr: 1, color: '#fff', fontSize: '1.3rem' }} />
@@ -1121,6 +1125,7 @@ const CollageLayoutSettings = ({
           }}
         />
       </Box>
+      )}
       
       {/* Border Thickness UI with Horizontal Scroller - Moved below Choose Layout */}
       <Box sx={{ mb: isMobile ? 0.25 : 0.5, position: 'relative' }}>

--- a/src/pages/CollagePage.js
+++ b/src/pages/CollagePage.js
@@ -70,7 +70,8 @@ export default function CollagePage() {
   const { user } = useContext(UserContext);
   const { openSubscriptionDialog } = useSubscribeDialog();
   const { clearAll } = useCollage();
-  const authorized = (user?.userDetails?.magicSubscription === "true" || user?.['cognito:groups']?.includes('admins'));
+  const isAdmin = user?.['cognito:groups']?.includes('admins');
+  const authorized = (user?.userDetails?.magicSubscription === "true" || isAdmin);
   
   const navigate = useNavigate();
   const location = useLocation();
@@ -120,7 +121,7 @@ export default function CollagePage() {
     libraryRefreshTrigger,
     autoSaveToLibrary,
     setAutoSaveToLibrary,
-  } = useCollageState();
+  } = useCollageState(isAdmin);
 
   // Check if all panels have images assigned (same logic as CollageImagesStep)
   const mappedPanels = Object.keys(panelImageMapping || {}).length;


### PR DESCRIPTION
## Summary
- gate library tools in BulkUploadSection behind admin check
- disable library auto-save by default for non-admins
- hide auto-save toggle for non-admins in collage settings
- pass admin flag into collage state hook

## Testing
- `npm run lint`
- `CI=true npm test -- -w 0 --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688a677fda1c832d98d66174985b4f99