### PR TITLE
Bug fixes for library

### DIFF
--- a/src/components/collage/components/BulkUploadSection.js
+++ b/src/components/collage/components/BulkUploadSection.js
@@ -760,7 +760,6 @@ const BulkUploadSection = ({
             ref={specificPanelFileInputRef}
             style={{ display: 'none' }}
             accept="image/*"
-            multiple
             onChange={handleSpecificPanelFileChange}
           />
 

--- a/src/components/collage/components/CollagePreview.js
+++ b/src/components/collage/components/CollagePreview.js
@@ -219,7 +219,6 @@ const CollagePreview = ({
         ref={fileInputRef}
         style={{ display: 'none' }}
         accept="image/*"
-        multiple
         onChange={handleFileChange}
       />
       

--- a/src/pages/V2FramePage.js
+++ b/src/pages/V2FramePage.js
@@ -150,48 +150,8 @@ export default function FramePage() {
             offScreenCanvas.width = maxCanvasWidth;
             offScreenCanvas.height = maxCanvasHeight;
             
-            // Draw the image
-            ctx.drawImage(img, 0, 0, maxCanvasWidth, maxCanvasHeight);
-            
-            // Add text overlay if enabled
-            if (showText && loadedSubtitle) {
-              // Text styling setup (similar to updateCanvasUnthrottled)
-              const referenceWidth = 1000;
-              const referenceFontSizeDesktop = 40;
-              const referenceFontSizeMobile = 40;
-              const referenceBottomAnch = 25;
-              const referenceBottomAnchMobile = 25;
-              const scaleFactor = 1000 / referenceWidth;
-              
-              const scaledFontSizeDesktop = referenceFontSizeDesktop * scaleFactor * fontSizeScaleFactor;
-              const scaledFontSizeMobile = referenceFontSizeMobile * scaleFactor * fontSizeScaleFactor;
-              const scaledBottomAnch = isMd ? referenceBottomAnch * scaleFactor * fontBottomMarginScaleFactor : referenceBottomAnchMobile * scaleFactor * fontBottomMarginScaleFactor;
-              const referenceLineHeight = 50;
-              const scaledLineHeight = referenceLineHeight * scaleFactor * fontLineHeightScaleFactor * fontSizeScaleFactor;
-              
-              // Apply text styling
-              const fontStyle = isItalic ? 'italic' : 'normal';
-              const fontWeight = isBold ? 'bold' : 'normal';
-              const fontColor = (typeof colorPickerColor === 'object') ? '#FFFFFF' : colorPickerColor;
-              
-              ctx.font = `${fontStyle} ${fontWeight} ${isMd ? scaledFontSizeDesktop : scaledFontSizeMobile}px ${fontFamily}`;
-              ctx.textAlign = 'center';
-              ctx.fillStyle = fontColor;
-              ctx.strokeStyle = getContrastColor(fontColor);
-              ctx.lineWidth = offScreenCanvas.width * 0.0044;
-              ctx.lineJoin = 'round';
-              
-              const x = offScreenCanvas.width / 2;
-              const maxWidth = offScreenCanvas.width - 60;
-              const text = isLowercaseFont ? loadedSubtitle.toLowerCase() : loadedSubtitle;
-              
-              // Calculate and draw text
-              const numOfLines = wrapText(ctx, text, x, 0, maxWidth, scaledLineHeight, false);
-              const totalTextHeight = numOfLines * scaledLineHeight;
-              const startYAdjusted = offScreenCanvas.height - totalTextHeight - scaledBottomAnch + 40;
-              
-              wrapText(ctx, text, x, startYAdjusted, maxWidth, scaledLineHeight);
-            }
+                      // Draw the image (original image without any text overlay)
+          ctx.drawImage(img, 0, 0, maxCanvasWidth, maxCanvasHeight);
             
             resolve();
           } catch (error) {


### PR DESCRIPTION
The PR includes the following fixes:

-Clicking empty frame on collage editor, it allowed you to select multiple to upload. It now only allows a single photo to upload.

-When we used the save to library button on the frame page, it engrained the subtitles into the imported image to library. It now uses the original image without engrained subtitles regardless if the frame page preview image is displaying subtitles or not.