### PR TITLE
Update frame extractor node version

### DIFF
--- a/amplify/backend/function/frameExtractor/frameExtractor-cloudformation-template.json
+++ b/amplify/backend/function/frameExtractor/frameExtractor-cloudformation-template.json
@@ -85,7 +85,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": "nodejs22.x",
         "MemorySize": 1024,
         "Layers": [],
         "Timeout": 25


### PR DESCRIPTION
This PR updates the lambda node version for `frameExtractor` from `18` to `22`