### PR TITLE
Implement legacy stack fallback for collage editor

### DIFF
--- a/src/components/collage/components/BulkUploadSection.js
+++ b/src/components/collage/components/BulkUploadSection.js
@@ -912,7 +912,6 @@ const BulkUploadSection = ({
                   isAdmin
                   multiple
                   minSelected={2}
-                  maxSelected={5}
                   refreshTrigger={libraryRefreshTrigger}
                   onSelect={(items) => handleLibrarySelect(items)}
                   showActionBar

--- a/src/components/collage/components/BulkUploadSection.js
+++ b/src/components/collage/components/BulkUploadSection.js
@@ -22,6 +22,7 @@ import {
   Clear
 } from '@mui/icons-material';
 import { LibraryBrowser } from '../../library';
+import { useNavigate } from 'react-router-dom';
 import { UserContext } from '../../../UserContext';
 import useLibraryData from '../../../hooks/library/useLibraryData';
 
@@ -129,6 +130,7 @@ const BulkUploadSection = ({
   const bulkFileInputRef = useRef(null);
   const panelScrollerRef = useRef(null);
   const specificPanelFileInputRef = useRef(null);
+  const navigate = useNavigate();
 
   // Admin: peek at library to decide what to show at start
   const {
@@ -594,6 +596,18 @@ const BulkUploadSection = ({
   // Handler for selecting images from LibraryBrowser
   const handleLibrarySelect = async (items) => {
     if (!items || items.length === 0) return;
+
+    // If selection exceeds 5, route to legacy Stack editor with images
+    if (items.length > 5) {
+      try {
+        navigate('/collage-legacy', { state: { fromCollage: true, images: items.map(it => ({
+          src: it.originalUrl || it.displayUrl || it.url || it,
+        })) } });
+      } catch (_) {
+        // swallow
+      }
+      return;
+    }
 
     const emptyPanels = [];
     const assignedPanelIds = new Set(Object.keys(panelImageMapping));

--- a/src/pages/CollagePage.js
+++ b/src/pages/CollagePage.js
@@ -88,9 +88,9 @@ export default function CollagePage() {
   const settingsRef = useRef(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  // Fallback dialog state when user exceeds 5 images
+  // Fallback dialog state when user selects more than 5 images at once
   const [showFallbackDialog, setShowFallbackDialog] = useState(false);
-  const [hasShownFallback, setHasShownFallback] = useState(false);
+  const [pendingImagesForLegacy, setPendingImagesForLegacy] = useState([]);
   
 
 
@@ -175,13 +175,13 @@ export default function CollagePage() {
     return undefined;
   }, [hasImages, showResultDialog]);
 
-  // If user adds more than 5 images, prompt to switch to legacy stack
+  // If a bulk add from library exceeds 5, BulkUploadSection/CollagePreview will route directly.
+  // Here we keep the dialog for awareness if state ever exceeds 5 for any reason.
   useEffect(() => {
-    if (!hasShownFallback && selectedImages.length > 5) {
+    if (selectedImages.length > 5 && !showFallbackDialog) {
       setShowFallbackDialog(true);
-      setHasShownFallback(true);
     }
-  }, [selectedImages.length, hasShownFallback]);
+  }, [selectedImages.length, showFallbackDialog]);
 
 
 
@@ -634,8 +634,8 @@ export default function CollagePage() {
           <Button
             variant="contained"
             onClick={() => {
-              // Navigate to legacy page; it persists its own state and supports unlimited images
-              navigate('/collage-legacy', { state: { fromCollage: true } });
+              const payload = selectedImages.map((img) => ({ src: img.displayUrl || img.originalUrl || img }));
+              navigate('/collage-legacy', { state: { fromCollage: true, images: payload } });
             }}
           >
             Use Stack

--- a/src/pages/CollagePageLegacy.js
+++ b/src/pages/CollagePageLegacy.js
@@ -718,7 +718,18 @@ export default function CollagePage() {
       }
     }
 
-    if (location.state?.updatedCollageState) {
+    if (location.state?.images && Array.isArray(location.state.images) && location.state.images.length > 0) {
+      // Accept images passed from new collage and initialize legacy stack
+      setImages(location.state.images.map(img => ({
+        id: Date.now().toString() + Math.random().toString(36).slice(2),
+        src: img.src || img.displayUrl || img.originalUrl || img,
+        width: img.width || img.naturalWidth || 1000,
+        height: img.height || img.naturalHeight || 1000,
+      })));
+      setHasAddedImages(true);
+      // Clear navigation state so refresh doesn't re-import
+      navigate(location.pathname, { replace: true, state: {} });
+    } else if (location.state?.updatedCollageState) {
       const { images, borderThickness, editMode, accordionExpanded } = location.state.updatedCollageState;
       setImages(images.map(img => ({
         ...img,


### PR DESCRIPTION
Enable a fallback to the legacy "Stack" collage editor when users select more than 5 images in the new editor, addressing its current image limit.

---
<a href="https://cursor.com/background-agent?bcId=bc-56fc901e-7755-4696-9408-76aefb90f551">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56fc901e-7755-4696-9408-76aefb90f551">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

