### PR TITLE
Simplify github release version display

### DIFF
--- a/src/layouts/dashboard/nav/index.js
+++ b/src/layouts/dashboard/nav/index.js
@@ -12,6 +12,7 @@ import NavSection from '../../../components/nav-section';
 import navConfig from './config';
 
 import { UserContext } from '../../../UserContext';
+import { formatReleaseTagForDisplay } from '../../../utils/githubReleases';
 
 const NAV_WIDTH = 280;
 
@@ -33,6 +34,12 @@ export default function Nav({ openNav, onCloseNav }) {
   const navigate = useNavigate();
   const userDetails = useContext(UserContext)
 
+  const baseVersion = `v${process.env.REACT_APP_VERSION || ''}`;
+  const formattedVersion = formatReleaseTagForDisplay(baseVersion) || baseVersion;
+  const versionLabel = process.env.REACT_APP_USER_BRANCH === 'beta'
+    ? formattedVersion
+    : `${formattedVersion}-${process.env.REACT_APP_USER_BRANCH}`;
+
   // useEffect(() => {
   //   if (openNav) {
   //     onCloseNav();
@@ -53,7 +60,7 @@ export default function Nav({ openNav, onCloseNav }) {
             <Logo />
           </Link>
           <Chip
-            label={process.env.REACT_APP_USER_BRANCH === 'beta' ? `v${process.env.REACT_APP_VERSION}` : `v${process.env.REACT_APP_VERSION}-${process.env.REACT_APP_USER_BRANCH}`}
+            label={versionLabel}
             size="small"
             clickable
             aria-label="View releases and version notes"

--- a/src/pages/ReleasesPage.tsx
+++ b/src/pages/ReleasesPage.tsx
@@ -32,6 +32,7 @@ import {
   getReleaseColor,
   formatRelativeTimeCompact,
   processGitHubLinks,
+  formatReleaseTagForDisplay,
 } from '../utils/githubReleases';
  
 
@@ -437,7 +438,7 @@ export default function ReleasesPage(): React.ReactElement {
                                 whiteSpace: 'nowrap'
                               }}
                             >
-                              {release.tag_name || title}
+                              {formatReleaseTagForDisplay(release.tag_name) || title}
                             </Typography>
                             <Chip 
                               size="small" 

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -21,6 +21,7 @@ import {
   fetchLatestRelease,
   getReleaseType,
   formatRelativeTimeCompact,
+  formatReleaseTagForDisplay,
   setDismissedVersion,
   getDismissedVersion,
 } from '../../utils/githubReleases';
@@ -352,7 +353,7 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
                             borderBottom: '1px solid rgba(255,255,255,0.4)'
                           }}
                         >
-                          {latestRelease?.tag_name}
+                          {formatReleaseTagForDisplay(latestRelease?.tag_name)}
                         </Link>{' '}
                       </Typography>
                       <Typography variant="body2" noWrap sx={{ opacity: 0.9, fontSize: { xs: '0.9rem', sm: '0.9rem' }, fontWeight: { xs: 500, sm: 500 }, ml: 'auto' }}>
@@ -415,7 +416,7 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
                               borderBottom: '1px solid rgba(255,255,255,0.4)'
                             }}
                           >
-                            {latestRelease?.tag_name}
+                            {formatReleaseTagForDisplay(latestRelease?.tag_name)}
                           </Link>{' '}
                         </Typography>
                         <Typography variant="body2" noWrap sx={{ opacity: 0.9, fontSize: { xs: '0.9rem', sm: '0.9rem' }, fontWeight: { xs: 500, sm: 500 }, ml: 'auto' }}>

--- a/src/utils/githubReleases.ts
+++ b/src/utils/githubReleases.ts
@@ -168,6 +168,19 @@ export function getReleaseColor(type: ReleaseType, isPrerelease: boolean, isDraf
   }
 }
 
+export function formatReleaseTagForDisplay(tagName?: string): string {
+  if (!tagName) return '';
+  const match = tagName.match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return tagName;
+  const major = parseInt(match[1], 10);
+  const minor = parseInt(match[2], 10);
+  const patch = parseInt(match[3], 10);
+
+  if (patch > 0) return `v${major}.${minor}.${patch}`;
+  if (minor === 0) return `v${major}`;
+  return `v${major}.${Math.max(0, minor - 1)}`;
+}
+
 export function formatRelativeTimeCompact(dateString?: string): string {
   if (!dateString) return 'Draft';
   const then = new Date(dateString).getTime();


### PR DESCRIPTION
Adjusts GitHub release tag display to simplify version numbers in the UI.

This PR introduces a `formatReleaseTagForDisplay` utility to centralize the display logic for release tags:
- `vX.Y.0` becomes `vX.(Y-1)` (e.g., `v2.13.0` → `v2.12`)
- `vX.0.0` becomes `vX` (e.g., `v3.0.0` → `v3`)
- `vX.Y.Z` where `Z > 0` remains `vX.Y.Z` (e.g., `v3.0.1` → `v3.0.1`)
This formatting is applied to the sidebar version chip, the releases page title, and the homepage update alert.

---
<a href="https://cursor.com/background-agent?bcId=bc-347b5423-4833-43a4-bc7d-4d471cb661fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-347b5423-4833-43a4-bc7d-4d471cb661fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

