### PR TITLE
Simplify github release version display

### DIFF
--- a/src/layouts/dashboard/nav/index.js
+++ b/src/layouts/dashboard/nav/index.js
@@ -12,6 +12,7 @@ import NavSection from '../../../components/nav-section';
 import navConfig from './config';
 
 import { UserContext } from '../../../UserContext';
+import { formatReleaseDisplay } from '../../../utils/githubReleases';
 
 const NAV_WIDTH = 280;
 
@@ -53,7 +54,9 @@ export default function Nav({ openNav, onCloseNav }) {
             <Logo />
           </Link>
           <Chip
-            label={process.env.REACT_APP_USER_BRANCH === 'beta' ? `v${process.env.REACT_APP_VERSION}` : `v${process.env.REACT_APP_VERSION}-${process.env.REACT_APP_USER_BRANCH}`}
+            label={process.env.REACT_APP_USER_BRANCH === 'beta' 
+              ? formatReleaseDisplay(`v${process.env.REACT_APP_VERSION}`)
+              : `${formatReleaseDisplay(`v${process.env.REACT_APP_VERSION}`)}-${process.env.REACT_APP_USER_BRANCH}`}
             size="small"
             clickable
             aria-label="View releases and version notes"

--- a/src/pages/ReleasesPage.tsx
+++ b/src/pages/ReleasesPage.tsx
@@ -32,6 +32,7 @@ import {
   getReleaseColor,
   formatRelativeTimeCompact,
   processGitHubLinks,
+  formatReleaseDisplay,
 } from '../utils/githubReleases';
  
 
@@ -437,7 +438,7 @@ export default function ReleasesPage(): React.ReactElement {
                                 whiteSpace: 'nowrap'
                               }}
                             >
-                              {release.tag_name || title}
+                              {formatReleaseDisplay(release.tag_name || title)}
                             </Typography>
                             <Chip 
                               size="small" 

--- a/src/sections/search/FullScreenSearch.js
+++ b/src/sections/search/FullScreenSearch.js
@@ -23,6 +23,7 @@ import {
   formatRelativeTimeCompact,
   setDismissedVersion,
   getDismissedVersion,
+  formatReleaseDisplay,
 } from '../../utils/githubReleases';
 
 
@@ -352,7 +353,7 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
                             borderBottom: '1px solid rgba(255,255,255,0.4)'
                           }}
                         >
-                          {latestRelease?.tag_name}
+                          {formatReleaseDisplay(latestRelease?.tag_name)}
                         </Link>{' '}
                       </Typography>
                       <Typography variant="body2" noWrap sx={{ opacity: 0.9, fontSize: { xs: '0.9rem', sm: '0.9rem' }, fontWeight: { xs: 500, sm: 500 }, ml: 'auto' }}>
@@ -415,7 +416,7 @@ export default function FullScreenSearch({ searchTerm, setSearchTerm, seriesTitl
                               borderBottom: '1px solid rgba(255,255,255,0.4)'
                             }}
                           >
-                            {latestRelease?.tag_name}
+                            {formatReleaseDisplay(latestRelease?.tag_name)}
                           </Link>{' '}
                         </Typography>
                         <Typography variant="body2" noWrap sx={{ opacity: 0.9, fontSize: { xs: '0.9rem', sm: '0.9rem' }, fontWeight: { xs: 500, sm: 500 }, ml: 'auto' }}>

--- a/src/utils/githubReleases.ts
+++ b/src/utils/githubReleases.ts
@@ -228,4 +228,31 @@ export function setDismissedVersion(tagName: string): void {
   }
 }
 
+export function formatReleaseDisplay(input?: string): string {
+  if (!input || typeof input !== 'string') return input || '';
+  const trimmed = input.trim();
+
+  const fullSemverMatch = trimmed.match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (fullSemverMatch) {
+    const [, major, minor, patch] = fullSemverMatch;
+    if (patch !== '0') return `v${major}.${minor}.${patch}`;
+    if (minor !== '0') return `v${major}.${minor}`;
+    return `v${major}`;
+  }
+
+  const twoPartMatch = trimmed.match(/^v?(\d+)\.(\d+)$/);
+  if (twoPartMatch) {
+    const [, major, minor] = twoPartMatch;
+    return `v${major}.${minor}`;
+  }
+
+  const onePartMatch = trimmed.match(/^v?(\d+)$/);
+  if (onePartMatch) {
+    const [, major] = onePartMatch;
+    return `v${major}`;
+  }
+
+  return trimmed;
+}
+
 


### PR DESCRIPTION
Format GitHub release names to remove trailing '.0' segments for a cleaner display across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-886f156a-b881-46ad-87b5-7a165f066031">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-886f156a-b881-46ad-87b5-7a165f066031">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

