### PR TITLE
Simplify collage page content

### DIFF
--- a/src/components/collage/components/BulkUploadSection.js
+++ b/src/components/collage/components/BulkUploadSection.js
@@ -152,6 +152,7 @@ const BulkUploadSection = ({
 
   // Determine if admin has any uploaded (non-placeholder) library items
   const adminHasLibraryItems = isAdmin && Boolean(adminLibraryItems?.some((it) => it?.key));
+  const helperSourceLabel = adminHasLibraryItems ? 'library' : 'device';
 
   // Check if there are any empty frames
   const hasEmptyFrames = () => {
@@ -843,6 +844,15 @@ const BulkUploadSection = ({
       ) : (
         // Starting point: distinct for admins vs non-admins
         <Box>
+          <Typography
+            variant="subtitle1"
+            sx={{
+              color: 'text.secondary',
+              mb: 1.5,
+            }}
+          >
+            Add up to 5 images from your {helperSourceLabel}
+          </Typography>
           {!isAdmin ? (
             // Non-admins: only the collage bulk upload dropzone
             <>
@@ -909,15 +919,6 @@ const BulkUploadSection = ({
             <>
               {adminHasLibraryItems ? (
                 <>
-                  <Typography
-                    variant="subtitle1"
-                    sx={{
-                      color: 'text.secondary',
-                      mb: 1.5,
-                    }}
-                  >
-                    Select up to 5 images from your library to make a collage
-                  </Typography>
                   <LibraryBrowser
                   isAdmin
                   multiple

--- a/src/components/collage/components/BulkUploadSection.js
+++ b/src/components/collage/components/BulkUploadSection.js
@@ -908,7 +908,17 @@ const BulkUploadSection = ({
             // Admins: either show Library only, or an "Add photos to your library" dropzone when empty
             <>
               {adminHasLibraryItems ? (
-                <LibraryBrowser
+                <>
+                  <Typography
+                    variant="subtitle1"
+                    sx={{
+                      color: 'text.secondary',
+                      mb: 1.5,
+                    }}
+                  >
+                    Select up to 5 images from your library to make a collage
+                  </Typography>
+                  <LibraryBrowser
                   isAdmin
                   multiple
                   minSelected={2}
@@ -920,6 +930,7 @@ const BulkUploadSection = ({
                   showSelectToggle
                   initialSelectMode
                 />
+                </>
               ) : (
                 <>
                   <Box sx={{ 

--- a/src/components/collage/components/EarlyAccessFeedback.js
+++ b/src/components/collage/components/EarlyAccessFeedback.js
@@ -48,12 +48,12 @@ const setCollagePreference = (user, preference) => {
   localStorage.setItem(key, preference);
 };
 
-export default function EarlyAccessFeedback() {
+export default function EarlyAccessFeedback({ defaultExpanded = false, onCollapsed }) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const navigate = useNavigate();
   
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded);
   
   // Feedback section state
   const [feedbackExpanded, setFeedbackExpanded] = useState(false);
@@ -128,11 +128,20 @@ export default function EarlyAccessFeedback() {
   // Close and reset
   const handleClose = () => {
     setExpanded(false);
+    if (typeof onCollapsed === 'function') onCollapsed();
     setMessageInput('');
     setEmailConsent(false);
     setFormSubmitted(false);
     setMessageError(false);
     setEmailConsentError(false);
+  };
+
+  const toggleExpanded = () => {
+    setExpanded(prev => {
+      const next = !prev;
+      if (!next && typeof onCollapsed === 'function') onCollapsed();
+      return next;
+    });
   };
 
   const validateForm = () => {
@@ -223,7 +232,7 @@ export default function EarlyAccessFeedback() {
             backgroundColor: 'rgba(255, 152, 0, 0.05)'
           }
         }}
-        onClick={() => setExpanded(!expanded)}
+        onClick={toggleExpanded}
         >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
             <ScienceIcon sx={{ 

--- a/src/pages/CollagePage.js
+++ b/src/pages/CollagePage.js
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState, useRef, useCallback } from "react";
 import { Helmet } from "react-helmet-async";
 import { useTheme } from "@mui/material/styles";
-import { useMediaQuery, Box, Container, Typography, Button, Slide, Stack, Collapse } from "@mui/material";
+import { useMediaQuery, Box, Container, Typography, Button, Slide, Stack, Collapse, Chip } from "@mui/material";
 import { Dashboard, Save, DeleteForever, Settings } from "@mui/icons-material";
 import { useNavigate, useLocation } from 'react-router-dom';
 import { UserContext } from "../UserContext";
@@ -88,6 +88,7 @@ export default function CollagePage() {
   const settingsRef = useRef(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [isCaptionEditorOpen, setIsCaptionEditorOpen] = useState(false);
+  const [showEarlyAccess, setShowEarlyAccess] = useState(false);
   
 
 
@@ -583,11 +584,34 @@ export default function CollagePage() {
                 textShadow: '0px 2px 4px rgba(0,0,0,0.15)'
               }}>
                 <Dashboard sx={{ mr: 2, color: 'inherit', fontSize: 40 }} /> 
-                Collage Tool
+                <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center' }}>
+                  Collage
+                  {!showEarlyAccess && (
+                    <Chip 
+                      label="BETA" 
+                      size="small" 
+                      onClick={() => setShowEarlyAccess(true)}
+                      sx={{ 
+                        backgroundColor: '#ff9800',
+                        color: '#000',
+                        fontWeight: 'bold',
+                        fontSize: '0.65rem',
+                        height: 20,
+                        ml: 1,
+                        cursor: 'pointer'
+                      }} 
+                    />
+                  )}
+                </Box>
               </Typography>
             </Box>
 
-            <EarlyAccessFeedback />
+            <Collapse in={showEarlyAccess} unmountOnExit>
+              <EarlyAccessFeedback 
+                defaultExpanded
+                onCollapsed={() => setShowEarlyAccess(false)}
+              />
+            </Collapse>
 
             <CollageLayout
               settingsStepProps={settingsStepProps}

--- a/src/pages/CollagePage.js
+++ b/src/pages/CollagePage.js
@@ -585,14 +585,6 @@ export default function CollagePage() {
                 <Dashboard sx={{ mr: 2, color: 'inherit', fontSize: 40 }} /> 
                 Collage Tool
               </Typography>
-              <Typography variant="subtitle1" sx={{ 
-                color: 'text.secondary',
-                mb: isMobile ? 2 : 1.5,
-                pl: isMobile ? 1 : 0,
-                maxWidth: '85%'
-              }}>
-                Merge images together to create multi-panel memes
-              </Typography>
             </Box>
 
             <EarlyAccessFeedback />


### PR DESCRIPTION
## Description

This PR simplifies the content on the collage page:
- Hides the beta controls card
- Clarifies the instructions
- Simplifies the title

## Preview

![ezgif-5750f4ac70fb42](https://github.com/user-attachments/assets/5d4715f5-900c-4d3c-a583-05d3de33e3b8)
