### PR TITLE
Add aws-sdk packages to lambda functions that use it

### DIFF
--- a/amplify/backend/function/memesrcAggregateVotes/src/package.json
+++ b/amplify/backend/function/memesrcAggregateVotes/src/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.388.0",
     "@aws-sdk/util-dynamodb": "^3.388.0",
-    "@opensearch-project/opensearch": "^2.12.0"
+    "@opensearch-project/opensearch": "^2.12.0",
+    "aws-sdk": "^2.1692.0"
   }
 }

--- a/amplify/backend/function/memesrcIndexToOpenSearch/src/package.json
+++ b/amplify/backend/function/memesrcIndexToOpenSearch/src/package.json
@@ -6,5 +6,8 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/aws-lambda": "^8.10.92"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.1692.0"
   }
 }

--- a/amplify/backend/function/memesrcOpenSearch/src/package.json
+++ b/amplify/backend/function/memesrcOpenSearch/src/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@opensearch-project/opensearch": "^2.6.0",
     "axios": "^1.6.8",
-    "csv-parser": "^3.0.0"
+    "csv-parser": "^3.0.0",
+    "aws-sdk": "^2.1692.0"
   }
 }

--- a/amplify/backend/function/memesrcPublicStripeFunction/src/package.json
+++ b/amplify/backend/function/memesrcPublicStripeFunction/src/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.382.0",
-    "stripe": "^12.16.0"
+    "stripe": "^12.16.0",
+    "aws-sdk": "^2.1692.0"
   }
 }


### PR DESCRIPTION
This PR adds the `aws-sdk` package to the `package.json` files for lambda functions that use it