### PR TITLE
Improve generative fill aspect ratio selection

### DIFF
--- a/amplify/backend/function/memesrcOpenAI/src/index.js
+++ b/amplify/backend/function/memesrcOpenAI/src/index.js
@@ -60,7 +60,7 @@ exports.handler = async (event) => {
     const s3Client = new S3Client({ region: "us-east-1" });
     const dynamoClient = new DynamoDBClient({ region: "us-east-1" });
 
-    const { magicResultId, imageKey, maskKey, prompt } = event;
+    const { magicResultId, imageKey, maskKey, prompt, size, input_fidelity } = event;
 
     const command = new GetParameterCommand({ Name: process.env.openai_apikey, WithDecryption: true });
     const data = await ssmClient.send(command);
@@ -89,7 +89,14 @@ exports.handler = async (event) => {
     });
     formData.append('prompt', prompt);
     formData.append('n', 2);
-    formData.append('size', "1024x1024");
+    if (size) {
+        formData.append('size', size);
+    } else {
+        formData.append('size', "1024x1024");
+    }
+    if (input_fidelity) {
+        formData.append('input_fidelity', input_fidelity);
+    }
 
     const headers = {
         'Authorization': `Bearer ${data.Parameter.Value}`,

--- a/amplify/backend/function/memesrcinpainter/src/index.js
+++ b/amplify/backend/function/memesrcinpainter/src/index.js
@@ -43,6 +43,8 @@ exports.handler = async (event) => {
     const userSub = (event.requestContext?.identity?.cognitoAuthenticationProvider) ? event.requestContext.identity.cognitoAuthenticationProvider.split(':').slice(-1) : '';
     const body = JSON.parse(event.body);
     const prompt = body.prompt;
+    const requestedSize = body.size; // e.g., "1024x1536" | "1536x1024" | "1024x1024"
+    const inputFidelity = body.input_fidelity; // e.g., "high"
 
     console.log(JSON.stringify(process.env))
 
@@ -120,7 +122,9 @@ exports.handler = async (event) => {
             magicResultId: dynamoRecord.id.S,
             imageKey,
             maskKey,
-            prompt
+            prompt,
+            size: requestedSize,
+            input_fidelity: inputFidelity
         })
     }));
 

--- a/src/pages/V2EditorPage.js
+++ b/src/pages/V2EditorPage.js
@@ -145,6 +145,7 @@ const EditorPage = ({ shows }) => {
   // const [earlyAccessLoading, setEarlyAccessLoading] = useState(false);
 
   const [variationDisplayColumns, setVariationDisplayColumns] = useState(1);
+  const [lastGenerativeMapping, setLastGenerativeMapping] = useState(null);
 
   // const [earlyAccessComplete, setEarlyAccessComplete] = useState(false);
   // const [earlyAccessDisabled, setEarlyAccessDisabled] = useState(false);
@@ -795,6 +796,35 @@ const EditorPage = ({ shows }) => {
     link.click();
   };
 
+  // Supported output sizes for gpt-image-1 edits
+  const SUPPORTED_GENERATIVE_SIZES = [
+    { width: 1024, height: 1024 },
+    { width: 1024, height: 1536 },
+    { width: 1536, height: 1024 },
+  ];
+
+  const chooseClosestSupportedSizeFor = (sourceWidth, sourceHeight) => {
+    const aspect = sourceWidth / sourceHeight;
+    let best = SUPPORTED_GENERATIVE_SIZES[0];
+    let bestDiff = Math.abs(aspect - (best.width / best.height));
+    for (let i = 1; i < SUPPORTED_GENERATIVE_SIZES.length; i += 1) {
+      const candidate = SUPPORTED_GENERATIVE_SIZES[i];
+      const diff = Math.abs(aspect - (candidate.width / candidate.height));
+      if (diff < bestDiff) {
+        best = candidate;
+        bestDiff = diff;
+      }
+    }
+    return best;
+  };
+
+  const computeContainScaleAndOffset = (srcWidth, srcHeight, targetWidth, targetHeight) => {
+    const scale = Math.min(targetWidth / srcWidth, targetHeight / srcHeight);
+    const offsetX = (targetWidth - (srcWidth * scale)) / 2;
+    const offsetY = (targetHeight - (srcHeight * scale)) / 2;
+    return { scale, offsetX, offsetY };
+  };
+
   const exportDrawing = async () => {
     setLoadingInpaintingResult(true)
     window.scrollTo(0, 0);
@@ -803,19 +833,18 @@ const EditorPage = ({ shows }) => {
     // let fabricImage = null;
 
     const tempCanvasDrawing = new fabric.Canvas();
-    tempCanvasDrawing.setWidth(1024);
-    tempCanvasDrawing.setHeight(1024);
+    const originalHeight = editor.canvas.height;
+    const originalWidth = editor.canvas.width;
+    const { width: targetWidth, height: targetHeight } = chooseClosestSupportedSizeFor(originalWidth, originalHeight);
+    tempCanvasDrawing.setWidth(targetWidth);
+    tempCanvasDrawing.setHeight(targetHeight);
 
     tempCanvasDrawing.backgroundColor = 'black'
 
     // tempCanvasDrawing.add(solidRect);
 
-    const originalHeight = editor.canvas.height
-    const originalWidth = editor.canvas.width
-
-    const scale = Math.min(1024 / originalWidth, 1024 / originalHeight);
-    const offsetX = (1024 - originalWidth * scale) / 2;
-    const offsetY = (1024 - originalHeight * scale) / 2;
+    const { scale, offsetX, offsetY } = computeContainScaleAndOffset(originalWidth, originalHeight, targetWidth, targetHeight);
+    setLastGenerativeMapping({ width: targetWidth, height: targetHeight, scale, offsetX, offsetY });
 
     originalCanvas.getObjects().forEach((obj) => {
       if (obj instanceof fabric.Path) {
@@ -846,9 +875,7 @@ const EditorPage = ({ shows }) => {
 
     const imageWidth = backgroundImage.width
     const imageHeight = backgroundImage.height
-    const imageScale = Math.min(1024 / imageWidth, 1024 / imageHeight);
-    const imageOffsetX = (1024 - imageWidth * imageScale) / 2;
-    const imageOffsetY = (1024 - imageHeight * imageScale) / 2;
+    const { scale: imageScale, offsetX: imageOffsetX, offsetY: imageOffsetY } = computeContainScaleAndOffset(imageWidth, imageHeight, targetWidth, targetHeight);
 
     tempCanvasDrawing.clear();
 
@@ -867,6 +894,8 @@ const EditorPage = ({ shows }) => {
         image: dataURLBgImage,
         mask: dataURLDrawing,
         prompt: magicPrompt,
+        size: `${targetWidth}x${targetHeight}`,
+        input_fidelity: 'high',
       };
 
       try {
@@ -939,11 +968,19 @@ const EditorPage = ({ shows }) => {
 
         const originalHeight = editor.canvas.height;
         const originalWidth = editor.canvas.width;
-        const scale = Math.min(1024 / originalWidth, 1024 / originalHeight);
-        returnedImage.scale(1 / scale);
+        const mapping = lastGenerativeMapping || (() => {
+          const size = chooseClosestSupportedSizeFor(originalWidth, originalHeight);
+          const m = computeContainScaleAndOffset(originalWidth, originalHeight, size.width, size.height);
+          return { width: size.width, height: size.height, ...m };
+        })();
+
+        const invScale = 1 / mapping.scale;
+        returnedImage.scale(invScale);
+        // Position to crop away the letterbox padding used during generation
+        returnedImage.set({ left: -mapping.offsetX * invScale, top: -mapping.offsetY * invScale });
         editor.canvas.setBackgroundImage(returnedImage);
         setBgEditorStates(prevHistory => [...prevHistory, returnedImage]);
-        editor.canvas.backgroundImage.center();
+        // Do not re-center; we already aligned to crop padding
         editor.canvas.renderAll();
 
         setEditorTool('captions');


### PR DESCRIPTION
Implements dynamic sizing, letterboxing, and high fidelity for generative fill to improve quality and preserve aspect ratios.

Previously, generative fill operations (Magic Eraser/Fill) always forced a 1024x1024 square output, which could distort non-square images. This update now selects the closest supported API dimension (1024x1024, 1024x1536, or 1536x1024) based on the input image's aspect ratio. The input image is padded (letterboxed) to this target size before being sent to the API, and the result is then cropped back to the original aspect ratio. Additionally, `input_fidelity="high"` is now passed to the API to better preserve details.

---
<a href="https://cursor.com/background-agent?bcId=bc-4faf230b-a2ec-49d6-92f8-206830150dc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4faf230b-a2ec-49d6-92f8-206830150dc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

