### PR TITLE
Add optional chaining to filtered users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.13.6",
+  "version": "2.13.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.13.6",
+      "version": "2.13.7",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.13.6",
+  "version": "2.13.7",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/sections/@dashboard/user/user-list.js
+++ b/src/sections/@dashboard/user/user-list.js
@@ -140,10 +140,10 @@ const UserList = () => {
     // Function to filter users based on search term
     const filteredUsers = users.filter((user) => {
         const { username, email } = user;
-        const searchTermLower = searchTerm.toLowerCase();
+        const searchTermLower = searchTerm?.toLowerCase();
         return (
-            username.toLowerCase().includes(searchTermLower) ||
-            email.toLowerCase().includes(searchTermLower)
+            username?.toLowerCase().includes(searchTermLower) ||
+            email?.toLowerCase().includes(searchTermLower)
         );
     });
 


### PR DESCRIPTION
This PR fixes a bug when loading all users via the search by adding optional chaining to the values in the filter.