### PR TITLE
Improve selector behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesrc",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memesrc",
-      "version": "2.16.0",
+      "version": "2.16.1",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.388.0",
         "@aws-sdk/util-dynamodb": "^3.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memesrc",
   "author": "vibehouse.net",
   "licence": "MIT",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/SeriesSelectorDialog.tsx
+++ b/src/components/SeriesSelectorDialog.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Dialog,
-  DialogTitle,
   DialogContent,
+  Popover,
   Box,
   TextField,
   InputAdornment,
@@ -43,6 +43,7 @@ export interface SeriesSelectorDialogProps {
   savedCids?: SeriesItem[];
   currentValueId?: string;
   includeAllFavorites?: boolean;
+  anchorEl?: HTMLElement | null;
 }
 
 function normalizeString(input: string): string {
@@ -211,11 +212,19 @@ const radioIconSx = (theme: Theme, selected: boolean, options?: { inverted?: boo
 };
 
 export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
-  const { open, onClose, onSelect, shows, savedCids, currentValueId, includeAllFavorites = true } = props;
+  const {
+    open,
+    onClose,
+    onSelect,
+    shows,
+    savedCids,
+    currentValueId,
+    includeAllFavorites = true,
+    anchorEl,
+  } = props;
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [filter, setFilter] = useState<string>('');
-  const [isInputFocused, setIsInputFocused] = useState<boolean>(false);
   const [favoriteOverrides, setFavoriteOverrides] = useState<Record<string, boolean>>({});
   const inputRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -261,13 +270,17 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
 
   // Reset state each time the dialog opens
   useEffect(() => {
-    if (open) {
-      setFilter('');
+    if (!open) return;
+    setFilter('');
+    requestAnimationFrame(() => {
+      contentRef.current?.scrollTo({ top: 0 });
+    });
+    if (!isMobile) {
       requestAnimationFrame(() => {
-        contentRef.current?.scrollTo({ top: 0 });
+        inputRef.current?.focus();
       });
     }
-  }, [open]);
+  }, [open, isMobile]);
 
   const handleSelect = (id: string) => {
     onSelect(id);
@@ -293,7 +306,7 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
     }
   };
 
-  const showQuickPicks = !isFiltering && !isInputFocused;
+  const showQuickPicks = !isFiltering;
   const favoritesForSection = showQuickPicks ? filteredFavorites : [];
   const showEverythingHeader = showQuickPicks;
   const hasFavoriteSelectionInQuick = showQuickPicks && favoritesForSection.some((fav) => fav.id === currentValueId);
@@ -328,261 +341,135 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
     });
   }, [baseSeries]);
 
-  return (
-    <Dialog
-      open={open}
-      onClose={onClose}
+  const renderFilterInput = () => (
+    <TextField
+      inputRef={inputRef}
+      variant="outlined"
       fullWidth
-      maxWidth={isMobile ? 'sm' : 'md'}
-      scroll="paper"
-      fullScreen={isMobile}
-      sx={isMobile ? { '& .MuiDialog-container': { alignItems: 'flex-start' }, '& .MuiDialog-paper': { margin: 0, borderRadius: 0 } } : { '& .MuiDialog-container': { alignItems: 'flex-start' }, '& .MuiDialog-paper': { mt: 2, borderRadius: 2 } }}
-    >
-      {!isMobile && (
-        <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Typography variant="h6" sx={{ flex: 1 }}>
-            Select show or movie
-          </Typography>
-          <IconButton aria-label="Close" onClick={onClose} size="small">
-            <CloseIcon fontSize="small" />
-          </IconButton>
-        </DialogTitle>
-      )}
-      <DialogContent dividers ref={contentRef} sx={{ p: 0 }}>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1,
-            px: 0,
-            py: 0,
-            minHeight: 64,
-            borderBottom: '1px solid',
-            borderColor: 'divider',
-            bgcolor: 'background.default',
-          }}
-        >
-          <IconButton
-            aria-label="Back"
-            size="small"
-            onClick={() => {
-              setFilter('');
-              onClose();
-            }}
-            sx={{
-              width: 40,
-              height: 40,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: 'text.primary',
-              '&:hover': { backgroundColor: 'action.hover' },
-            }}
-          >
-            <ChevronLeftIcon fontSize="medium" />
-          </IconButton>
-          <TextField
-            inputRef={inputRef}
-            variant="outlined"
-            fullWidth
-            placeholder="Type to filter (titles)..."
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onFocus={() => setIsInputFocused(true)}
-            onBlur={() => setIsInputFocused(false)}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon fontSize="small" sx={{ opacity: 0.8 }} />
-                </InputAdornment>
-              ),
-              endAdornment: (
-                filter ? (
-                  <InputAdornment position="end">
-                    <IconButton size="small" edge="end" onClick={(e) => { e.stopPropagation(); setFilter(''); }}>
-                      <CloseIcon fontSize="small" />
-                    </IconButton>
-                  </InputAdornment>
-                ) : null
-              )
-            }}
-            sx={{
-              '& .MuiOutlinedInput-root': {
-                borderRadius: 1,
-                bgcolor: 'background.paper',
-                minHeight: 52,
-                '& fieldset': { borderColor: 'divider' },
-                '&:hover fieldset': { borderColor: 'text.primary' },
-                '&.Mui-focused fieldset': { borderColor: 'primary.main', borderWidth: 1 },
-              },
-              '& .MuiOutlinedInput-input': {
-                fontSize: '1rem',
-                py: 1.25,
-              },
-            }}
-          />
-          <IconButton
-            aria-label="Done"
-            size="small"
-            onClick={() => {
-              inputRef.current?.blur();
-              onClose();
-            }}
-            sx={{
-              width: 40,
-              height: 40,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: 'text.primary',
-              '&:hover': { backgroundColor: 'action.hover' },
-            }}
-          >
-            <CheckIcon fontSize="medium" />
-          </IconButton>
+      placeholder="Type to filter (titles)..."
+      value={filter}
+      onChange={(e) => setFilter(e.target.value)}
+      onKeyDown={handleKeyDown}
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon fontSize="small" sx={{ opacity: 0.8 }} />
+          </InputAdornment>
+        ),
+        endAdornment: filter ? (
+          <InputAdornment position="end">
+            <IconButton
+              size="small"
+              edge="end"
+              onClick={(e) => {
+                e.stopPropagation();
+                setFilter('');
+              }}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </InputAdornment>
+        ) : null,
+      }}
+      sx={{
+        flex: 1,
+        '& .MuiOutlinedInput-root': {
+          borderRadius: isMobile ? 1 : 1.5,
+          bgcolor: 'background.paper',
+          minHeight: 52,
+          '& fieldset': { borderColor: 'divider' },
+          '&:hover fieldset': { borderColor: 'text.primary' },
+          '&.Mui-focused fieldset': { borderColor: 'primary.main', borderWidth: 1 },
+        },
+        '& .MuiOutlinedInput-input': {
+          fontSize: '1rem',
+          py: 1.25,
+        },
+      }}
+    />
+  );
+
+  const listContent = (
+    <List disablePadding sx={{ bgcolor: 'transparent', px: 2, pt: showQuickPicks ? 1.25 : 0.75, pb: 2 }}>
+
+      {/* Unified content: quick picks when no filter; results/full list below */}
+      {/* No results state */}
+      {isFiltering && filteredAllSeries.length === 0 && (
+        <Box sx={{ py: 4, textAlign: 'center', color: 'text.secondary' }}>
+          <Typography variant="body2">No results</Typography>
         </Box>
+      )}
 
-        <List disablePadding sx={{ bgcolor: 'transparent', px: 2, pt: showQuickPicks ? 1.25 : 0.75, pb: 2 }}>
-
-          {/* Unified content: quick picks when no filter; results/full list below */}
-          {/* No results state */}
-          {isFiltering && filteredAllSeries.length === 0 && (
-            <Box sx={{ py: 4, textAlign: 'center', color: 'text.secondary' }}>
-              <Typography variant="body2">No results</Typography>
+      {/* Quick picks when not filtering */}
+      {showQuickPicks && (
+        <>
+          <ListSubheader disableSticky component="div" sx={(theme) => sectionHeaderSx(theme, { topSpacing: 'tight' })}>
+            Quick Filters
+          </ListSubheader>
+          <ListItemButton
+            selected={currentValueId === '_universal'}
+            onClick={() => handleSelect('_universal')}
+            sx={(theme) => quickActionButtonSx(theme)}
+          >
+            <Box sx={(theme) => radioIconSx(theme, currentValueId === '_universal', { inverted: true })}>
+              {currentValueId === '_universal' ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
             </Box>
+            <Box component="span" sx={{ fontSize: 24, lineHeight: 1, mr: 1 }}>🌈</Box>
+            <ListItemText
+              sx={{ ml: 0, flex: 1 }}
+              primaryTypographyProps={{ sx: { fontWeight: 700, fontSize: '1.1rem', color: 'inherit' } }}
+              primary="All Shows & Movies"
+              secondary="Everything across shows and movies"
+              secondaryTypographyProps={{ sx: { color: 'inherit', opacity: 0.8 } }}
+            />
+          </ListItemButton>
+
+          {includeAllFavorites && hasAnyFavorite && (
+            <ListItemButton
+              selected={currentValueId === '_favorites'}
+              onClick={() => handleSelect('_favorites')}
+              sx={(theme) => ({
+                ...quickActionButtonSx(theme),
+                marginBottom: theme.spacing(1.5),
+              })}
+            >
+              <Box sx={(theme) => radioIconSx(theme, currentValueId === '_favorites', { inverted: true })}>
+                {currentValueId === '_favorites' ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
+              </Box>
+              <Box component="span" sx={{ fontSize: 24, lineHeight: 1, mr: 1 }}>⭐</Box>
+              <ListItemText
+                sx={{ ml: 0, flex: 1 }}
+                primaryTypographyProps={{ sx: { fontWeight: 700, fontSize: '1.1rem', color: 'inherit' } }}
+                primary="All Favorites"
+                secondary="Only items you've starred as favorites"
+                secondaryTypographyProps={{ sx: { color: 'inherit', opacity: 0.8 } }}
+              />
+            </ListItemButton>
           )}
 
-          {/* Quick picks when not filtering */}
-          {showQuickPicks && (
+          {favoritesForSection.length > 0 && (
             <>
-              <ListSubheader disableSticky component="div" sx={(theme) => sectionHeaderSx(theme, { topSpacing: 'tight' })}>
-                Quick Filters
-              </ListSubheader>
-              <ListItemButton
-                selected={currentValueId === '_universal'}
-                onClick={() => handleSelect('_universal')}
-                sx={(theme) => quickActionButtonSx(theme)}
+              <ListSubheader
+                disableSticky
+                component="div"
+                sx={(theme) => sectionHeaderSx(theme, { topSpacing: showQuickPicks ? 'regular' : 'tight' })}
               >
-                <Box sx={(theme) => radioIconSx(theme, currentValueId === '_universal', { inverted: true })}>
-                  {currentValueId === '_universal' ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
-                </Box>
-                <Box component="span" sx={{ fontSize: 24, lineHeight: 1, mr: 1 }}>🌈</Box>
-                <ListItemText
-                  sx={{ ml: 0, flex: 1 }}
-                  primaryTypographyProps={{ sx: { fontWeight: 700, fontSize: '1.1rem', color: 'inherit' } }}
-                  primary="All Shows & Movies"
-                  secondary="Everything across shows and movies"
-                  secondaryTypographyProps={{ sx: { color: 'inherit', opacity: 0.8 } }}
-                />
-              </ListItemButton>
-
-              {includeAllFavorites && hasAnyFavorite && (
-                <ListItemButton
-                  selected={currentValueId === '_favorites'}
-                  onClick={() => handleSelect('_favorites')}
-                  sx={(theme) => ({
-                    ...quickActionButtonSx(theme),
-                    marginBottom: theme.spacing(1.5),
-                  })}
-                >
-                  <Box sx={(theme) => radioIconSx(theme, currentValueId === '_favorites', { inverted: true })}>
-                    {currentValueId === '_favorites' ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
-                  </Box>
-                  <Box component="span" sx={{ fontSize: 24, lineHeight: 1, mr: 1 }}>⭐</Box>
-                  <ListItemText
-                    sx={{ ml: 0, flex: 1 }}
-                    primaryTypographyProps={{ sx: { fontWeight: 700, fontSize: '1.1rem', color: 'inherit' } }}
-                    primary="All Favorites"
-                    secondary="Only items you've starred as favorites"
-                    secondaryTypographyProps={{ sx: { color: 'inherit', opacity: 0.8 } }}
-                  />
-                </ListItemButton>
-              )}
-
-              {favoritesForSection.length > 0 && (
-                <>
-                  <ListSubheader
-                    disableSticky
-                    component="div"
-                    sx={(theme) => sectionHeaderSx(theme, { topSpacing: showQuickPicks ? 'regular' : 'tight' })}
+                Favorites
+              </ListSubheader>
+              {favoritesForSection.map((s) => {
+                const isSelected = currentValueId === s.id;
+                return (
+                  <ListItemButton
+                    key={s.id}
+                    selected={isSelected}
+                    onClick={() => handleSelect(s.id)}
+                    sx={(theme) => listCardButtonSx(theme, s)}
                   >
-                    Favorites
-                  </ListSubheader>
-                  {favoritesForSection.map((s) => {
-                    const isSelected = currentValueId === s.id;
-                    return (
-                      <ListItemButton
-                        key={s.id}
-                        selected={isSelected}
-                        onClick={() => handleSelect(s.id)}
-                        sx={(theme) => listCardButtonSx(theme, s)}
-                      >
-                        <Box sx={(theme) => radioIconSx(theme, isSelected, { inverted: true })}>
-                          {isSelected ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
-                        </Box>
-                        <Box component="span" sx={{ fontSize: 18, lineHeight: 1, mr: 1.25 }}>
-                          {s.emoji ? s.emoji : '⭐'}
-                        </Box>
-                        <ListItemText
-                          sx={{ ml: 0, flex: 1 }}
-                          primaryTypographyProps={{ sx: { fontWeight: 600, color: 'inherit' } }}
-                          primary={s.title}
-                        />
-                        <Box
-                          sx={{ ml: 'auto', display: 'flex', alignItems: 'center' }}
-                          onClick={(e) => e.stopPropagation()}
-                          onMouseDown={(e) => e.stopPropagation()}
-                          onTouchStart={(e) => e.stopPropagation()}
-                        >
-                          <FavoriteToggle
-                            indexId={s.id}
-                            initialIsFavorite={Boolean(s.isFavorite)}
-                            onToggle={(next) => handleFavoriteOverride(s.id, next)}
-                          />
-                        </Box>
-                      </ListItemButton>
-                    );
-                  })}
-                </>
-              )}
-            </>
-          )}
-
-              {filteredAllSeries.length > 0 && (
-                <>
-                  {showEverythingHeader && (
-                    <ListSubheader
-                      disableSticky
-                      component="div"
-                      sx={(theme) => sectionHeaderSx(
-                        theme,
-                        { topSpacing: showQuickPicks || favoritesForSection.length > 0 ? 'regular' : 'tight' }
-                      )}
-                    >
-                      Everything
-                    </ListSubheader>
-                  )}
-                  {filteredAllSeries.map((s, index) => {
-                    const isSelected = currentValueId === s.id && !(hasFavoriteSelectionInQuick && s.isFavorite);
-                    return (
-                      <ListItemButton
-                        key={s.id}
-                        selected={isSelected}
-                        onClick={() => handleSelect(s.id)}
-                        sx={(theme) => {
-                          const base = listCardButtonSx(theme, s);
-                          if (!showEverythingHeader && index === 0) {
-                            return { ...base, mt: theme.spacing(0.25) };
-                          }
-                          return base;
-                        }}
-                      >
                     <Box sx={(theme) => radioIconSx(theme, isSelected, { inverted: true })}>
                       {isSelected ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
                     </Box>
                     <Box component="span" sx={{ fontSize: 18, lineHeight: 1, mr: 1.25 }}>
-                      {s.emoji ? s.emoji : s.isFavorite ? '⭐' : '🎬'}
+                      {s.emoji ? s.emoji : '⭐'}
                     </Box>
                     <ListItemText
                       sx={{ ml: 0, flex: 1 }}
@@ -606,10 +493,225 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
               })}
             </>
           )}
-        </List>
-      </DialogContent>
+        </>
+      )}
 
-      
-    </Dialog>
+      {filteredAllSeries.length > 0 && (
+        <>
+          {showEverythingHeader && (
+            <ListSubheader
+              disableSticky
+              component="div"
+              sx={(theme) => sectionHeaderSx(
+                theme,
+                { topSpacing: showQuickPicks || favoritesForSection.length > 0 ? 'regular' : 'tight' }
+              )}
+            >
+              Everything
+            </ListSubheader>
+          )}
+          {filteredAllSeries.map((s, index) => {
+            const isSelected = currentValueId === s.id && !(hasFavoriteSelectionInQuick && s.isFavorite);
+            return (
+              <ListItemButton
+                key={s.id}
+                selected={isSelected}
+                onClick={() => handleSelect(s.id)}
+                sx={(theme) => {
+                  const base = listCardButtonSx(theme, s);
+                  if (!showEverythingHeader && index === 0) {
+                    return { ...base, mt: theme.spacing(0.25) };
+                  }
+                  return base;
+                }}
+              >
+                <Box sx={(theme) => radioIconSx(theme, isSelected, { inverted: true })}>
+                  {isSelected ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
+                </Box>
+                <Box component="span" sx={{ fontSize: 18, lineHeight: 1, mr: 1.25 }}>
+                  {s.emoji ? s.emoji : s.isFavorite ? '⭐' : '🎬'}
+                </Box>
+                <ListItemText
+                  sx={{ ml: 0, flex: 1 }}
+                  primaryTypographyProps={{ sx: { fontWeight: 600, color: 'inherit' } }}
+                  primary={s.title}
+                />
+                <Box
+                  sx={{ ml: 'auto', display: 'flex', alignItems: 'center' }}
+                  onClick={(e) => e.stopPropagation()}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onTouchStart={(e) => e.stopPropagation()}
+                >
+                  <FavoriteToggle
+                    indexId={s.id}
+                    initialIsFavorite={Boolean(s.isFavorite)}
+                    onToggle={(next) => handleFavoriteOverride(s.id, next)}
+                  />
+                </Box>
+              </ListItemButton>
+            );
+          })}
+        </>
+      )}
+    </List>
+  );
+
+  if (isMobile) {
+    return (
+      <Dialog
+        open={open}
+        onClose={onClose}
+        fullWidth
+        maxWidth="sm"
+        scroll="paper"
+        fullScreen
+        sx={{ '& .MuiDialog-container': { alignItems: 'flex-start' }, '& .MuiDialog-paper': { margin: 0, borderRadius: 0 } }}
+      >
+        <DialogContent
+          dividers
+          sx={{
+            p: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            bgcolor: 'background.default',
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              px: 1,
+              py: 0,
+              minHeight: 64,
+              borderBottom: '1px solid',
+              borderColor: 'divider',
+            }}
+          >
+            <IconButton
+              aria-label="Back"
+              size="small"
+              onClick={() => {
+                setFilter('');
+                onClose();
+              }}
+              sx={{
+                width: 40,
+                height: 40,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'text.primary',
+                '&:hover': { backgroundColor: 'action.hover' },
+              }}
+            >
+              <ChevronLeftIcon fontSize="medium" />
+            </IconButton>
+            {renderFilterInput()}
+            <IconButton
+              aria-label="Done"
+              size="small"
+              onClick={() => {
+                inputRef.current?.blur();
+                onClose();
+              }}
+              sx={{
+                width: 40,
+                height: 40,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'text.primary',
+                '&:hover': { backgroundColor: 'action.hover' },
+              }}
+            >
+              <CheckIcon fontSize="medium" />
+            </IconButton>
+          </Box>
+          <Box
+            ref={contentRef}
+            sx={{
+              flex: 1,
+              minHeight: 0,
+              overflowY: 'auto',
+              overflowX: 'hidden',
+              bgcolor: 'background.default',
+            }}
+          >
+            {listContent}
+          </Box>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  if (!anchorEl) return null;
+
+  return (
+    <Popover
+      open={open}
+      onClose={onClose}
+      anchorEl={anchorEl}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      PaperProps={{
+        sx: {
+          mt: 1,
+          width: 420,
+          maxWidth: 'min(420px, calc(100vw - 32px))',
+          maxHeight: 'calc(100vh - 96px)',
+          display: 'flex',
+          flexDirection: 'column',
+          borderRadius: 2,
+          overflow: 'hidden',
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          minHeight: 0,
+          bgcolor: 'background.paper',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 2,
+            pt: 1.5,
+            pb: 1,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Typography variant="subtitle1" sx={{ flex: 1, fontWeight: 700 }}>
+            Select show or movie
+          </Typography>
+          <IconButton aria-label="Close" size="small" onClick={onClose}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+        <Box sx={{ px: 2, py: 1, borderBottom: '1px solid', borderColor: 'divider' }}>
+          {renderFilterInput()}
+        </Box>
+        <Box
+          ref={contentRef}
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            overflowY: 'auto',
+            overflowX: 'hidden',
+            bgcolor: 'background.default',
+          }}
+        >
+          {listContent}
+        </Box>
+      </Box>
+    </Popover>
   );
 }

--- a/src/components/SeriesSelectorDialog.tsx
+++ b/src/components/SeriesSelectorDialog.tsx
@@ -105,15 +105,15 @@ const quickActionButtonSx = (theme: Theme) => {
   return {
     border: '1px solid',
     borderColor: borderTone,
-    borderRadius: 2,
-    marginBottom: theme.spacing(0.75),
-    paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(2),
-    paddingLeft: theme.spacing(1),
-    paddingRight: theme.spacing(1),
+    borderRadius: theme.spacing(1.5),
+    marginBottom: theme.spacing(0.6),
+    paddingTop: theme.spacing(1.35),
+    paddingBottom: theme.spacing(1.25),
+    paddingLeft: theme.spacing(1.1),
+    paddingRight: theme.spacing(1.1),
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(1.5),
+    gap: theme.spacing(1.15),
     boxShadow: theme.shadows[4],
     backgroundColor,
     backgroundImage: backgroundGradient,
@@ -128,9 +128,13 @@ const quickActionButtonSx = (theme: Theme) => {
     '& .MuiListItemText-primary': {
       color: textColor,
       fontWeight: 700,
+      fontSize: '1.02rem',
+      lineHeight: 1.2,
     },
     '& .MuiListItemText-secondary': {
       color: subTextColor,
+      fontSize: '0.82rem',
+      fontWeight: 500,
     },
     ...getSelectedListItemStyles(theme),
   };
@@ -425,12 +429,12 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
             <Box sx={(theme) => radioIconSx(theme, currentValueId === '_universal', { inverted: true })}>
               {currentValueId === '_universal' ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
             </Box>
-            <Box component="span" sx={{ fontSize: 24, lineHeight: 1, mr: 1 }}>🌈</Box>
+            <Box component="span" sx={{ fontSize: 22, lineHeight: 1, mr: 1 }}>🌈</Box>
             <ListItemText
               sx={{ ml: 0, flex: 1 }}
-              primaryTypographyProps={{ sx: { fontWeight: 700, fontSize: '1.1rem', color: 'inherit' } }}
+              primaryTypographyProps={{ sx: { fontWeight: 700, fontSize: '1.02rem', color: 'inherit' } }}
               primary="All Shows & Movies"
-              secondary="Everything across shows and movies"
+              secondary="Every quote in the library"
               secondaryTypographyProps={{ sx: { color: 'inherit', opacity: 0.8 } }}
             />
           </ListItemButton>
@@ -441,18 +445,18 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
               onClick={() => handleSelect('_favorites')}
               sx={(theme) => ({
                 ...quickActionButtonSx(theme),
-                marginBottom: theme.spacing(1.5),
+                marginBottom: theme.spacing(1.2),
               })}
             >
               <Box sx={(theme) => radioIconSx(theme, currentValueId === '_favorites', { inverted: true })}>
                 {currentValueId === '_favorites' ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
               </Box>
-              <Box component="span" sx={{ fontSize: 24, lineHeight: 1, mr: 1 }}>⭐</Box>
+              <Box component="span" sx={{ fontSize: 22, lineHeight: 1, mr: 1 }}>⭐</Box>
               <ListItemText
                 sx={{ ml: 0, flex: 1 }}
-                primaryTypographyProps={{ sx: { fontWeight: 700, fontSize: '1.1rem', color: 'inherit' } }}
+                primaryTypographyProps={{ sx: { fontWeight: 700, fontSize: '1.02rem', color: 'inherit' } }}
                 primary="All Favorites"
-                secondary="Only items you've starred as favorites"
+                secondary="Only your saved favorites"
                 secondaryTypographyProps={{ sx: { color: 'inherit', opacity: 0.8 } }}
               />
             </ListItemButton>

--- a/src/components/SeriesSelectorDialog.tsx
+++ b/src/components/SeriesSelectorDialog.tsx
@@ -3,6 +3,7 @@ import {
   Dialog,
   DialogContent,
   Popover,
+  type PopoverProps,
   Box,
   TextField,
   InputAdornment,
@@ -311,6 +312,8 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
   const showEverythingHeader = showQuickPicks;
   const hasFavoriteSelectionInQuick = showQuickPicks && favoritesForSection.some((fav) => fav.id === currentValueId);
 
+  const desktopMaxHeight = isFiltering ? 'calc(100vh - 96px)' : 'min(480px, calc(100vh - 96px))';
+
   const handleFavoriteOverride = useCallback((id: string, nextIsFavorite: boolean) => {
     setFavoriteOverrides((prev) => {
       const baseItem = baseSeries.find((s) => s.id === id);
@@ -390,7 +393,15 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
   );
 
   const listContent = (
-    <List disablePadding sx={{ bgcolor: 'transparent', px: 2, pt: showQuickPicks ? 1.25 : 0.75, pb: 2 }}>
+    <List
+      disablePadding
+      sx={{
+        bgcolor: 'transparent',
+        px: { xs: 1.5, sm: 2 },
+        pt: showQuickPicks ? (isMobile ? 1 : 1.25) : isMobile ? 0.6 : 0.75,
+        pb: { xs: 1.5, sm: 2 },
+      }}
+    >
 
       {/* Unified content: quick picks when no filter; results/full list below */}
       {/* No results state */}
@@ -556,7 +567,21 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
     </List>
   );
 
-  if (isMobile) {
+  const mobileMaxHeight = isFiltering
+    ? 'min(520px, calc(100vh - 112px))'
+    : 'min(460px, calc(100vh - 112px))';
+
+  const popoverAnchorOrigin: PopoverProps['anchorOrigin'] = isMobile
+    ? { vertical: 'bottom', horizontal: 'center' }
+    : { vertical: 'bottom', horizontal: 'left' };
+
+  const popoverTransformOrigin: PopoverProps['transformOrigin'] = isMobile
+    ? { vertical: 'top', horizontal: 'center' }
+    : { vertical: 'top', horizontal: 'left' };
+
+  if (!anchorEl) {
+    if (!isMobile) return null;
+
     return (
       <Dialog
         open={open}
@@ -564,14 +589,26 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
         fullWidth
         maxWidth="sm"
         scroll="paper"
-        fullScreen
-        sx={{ '& .MuiDialog-container': { alignItems: 'flex-start' }, '& .MuiDialog-paper': { margin: 0, borderRadius: 0 } }}
+        sx={{ '& .MuiDialog-container': { alignItems: 'flex-start' } }}
+        PaperProps={{
+          sx: {
+            width: 'calc(100vw - 24px)',
+            maxWidth: 440,
+            height: 'min(80vh, 600px)',
+            mt: 2,
+            borderRadius: 3,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+          },
+        }}
       >
         <DialogContent
           dividers
           sx={{
             p: 0,
             display: 'flex',
+            flex: 1,
             flexDirection: 'column',
             minHeight: 0,
             bgcolor: 'background.default',
@@ -646,26 +683,25 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
     );
   }
 
-  if (!anchorEl) return null;
-
   return (
     <Popover
       open={open}
       onClose={onClose}
       anchorEl={anchorEl}
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      anchorOrigin={popoverAnchorOrigin}
+      transformOrigin={popoverTransformOrigin}
       PaperProps={{
-        sx: {
-          mt: 1,
-          width: 420,
-          maxWidth: 'min(420px, calc(100vw - 32px))',
-          maxHeight: 'calc(100vh - 96px)',
+        sx: (theme) => ({
+          mt: isMobile ? 0.75 : 1,
+          width: isMobile ? 'min(420px, calc(100vw - 24px))' : 420,
+          maxWidth: 'min(420px, calc(100vw - 24px))',
+          maxHeight: isMobile ? mobileMaxHeight : desktopMaxHeight,
           display: 'flex',
           flexDirection: 'column',
-          borderRadius: 2,
+          borderRadius: isMobile ? theme.spacing(1.75) : theme.spacing(1.25),
           overflow: 'hidden',
-        },
+          boxShadow: isMobile ? theme.shadows[10] : theme.shadows[12],
+        }),
       }}
     >
       <Box
@@ -682,9 +718,9 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
             display: 'flex',
             alignItems: 'center',
             gap: 1,
-            px: 2,
-            pt: 1.5,
-            pb: 1,
+            px: isMobile ? 1.5 : 2,
+            pt: isMobile ? 1.25 : 1.5,
+            pb: isMobile ? 0.75 : 1,
             borderBottom: '1px solid',
             borderColor: 'divider',
           }}
@@ -696,7 +732,14 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
             <CloseIcon fontSize="small" />
           </IconButton>
         </Box>
-        <Box sx={{ px: 2, py: 1, borderBottom: '1px solid', borderColor: 'divider' }}>
+        <Box
+          sx={{
+            px: isMobile ? 1.5 : 2,
+            py: isMobile ? 0.75 : 1,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
           {renderFilterInput()}
         </Box>
         <Box

--- a/src/components/SeriesSelectorDialog.tsx
+++ b/src/components/SeriesSelectorDialog.tsx
@@ -568,8 +568,8 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
   );
 
   const mobileMaxHeight = isFiltering
-    ? 'min(520px, calc(100vh - 112px))'
-    : 'min(460px, calc(100vh - 112px))';
+    ? 'min(560px, calc(100vh - 96px))'
+    : 'min(500px, calc(100vh - 96px))';
 
   const popoverAnchorOrigin: PopoverProps['anchorOrigin'] = isMobile
     ? { vertical: 'bottom', horizontal: 'center' }
@@ -591,16 +591,25 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
         scroll="paper"
         sx={{ '& .MuiDialog-container': { alignItems: 'flex-start' } }}
         PaperProps={{
-          sx: {
-            width: 'calc(100vw - 24px)',
-            maxWidth: 440,
-            height: 'min(80vh, 600px)',
+          sx: (theme) => ({
+            width: 'calc(100vw - 28px)',
+            maxWidth: 420,
+            height: 'min(85vh, 640px)',
             mt: 2,
-            borderRadius: 3,
+            borderRadius: theme.spacing(2.75),
             display: 'flex',
             flexDirection: 'column',
             overflow: 'hidden',
-          },
+            border: '1px solid',
+            borderColor: theme.palette.mode === 'light'
+              ? alpha(theme.palette.common.black, 0.1)
+              : alpha(theme.palette.common.white, 0.24),
+            backgroundImage: theme.palette.mode === 'light'
+              ? `linear-gradient(180deg, ${alpha(theme.palette.background.paper, 0.98)} 0%, ${alpha(theme.palette.background.paper, 0.94)} 100%)`
+              : `linear-gradient(180deg, ${alpha(theme.palette.background.default, 0.94)} 0%, ${alpha(theme.palette.background.default, 0.86)} 100%)`,
+            boxShadow: theme.shadows[18],
+            backdropFilter: 'blur(16px)',
+          }),
         }}
       >
         <DialogContent
@@ -692,15 +701,23 @@ export default function SeriesSelectorDialog(props: SeriesSelectorDialogProps) {
       transformOrigin={popoverTransformOrigin}
       PaperProps={{
         sx: (theme) => ({
-          mt: isMobile ? 0.75 : 1,
-          width: isMobile ? 'min(420px, calc(100vw - 24px))' : 420,
-          maxWidth: 'min(420px, calc(100vw - 24px))',
+          mt: isMobile ? 0.9 : 1,
+          width: isMobile ? 'min(360px, calc(100vw - 32px))' : 420,
+          maxWidth: isMobile ? 'min(360px, calc(100vw - 32px))' : 'min(420px, calc(100vw - 32px))',
           maxHeight: isMobile ? mobileMaxHeight : desktopMaxHeight,
           display: 'flex',
           flexDirection: 'column',
-          borderRadius: isMobile ? theme.spacing(1.75) : theme.spacing(1.25),
+          borderRadius: isMobile ? theme.spacing(2) : theme.spacing(1.5),
           overflow: 'hidden',
-          boxShadow: isMobile ? theme.shadows[10] : theme.shadows[12],
+          border: '1px solid',
+          borderColor: theme.palette.mode === 'light'
+            ? alpha(theme.palette.common.black, 0.12)
+            : alpha(theme.palette.common.white, 0.26),
+          backgroundImage: theme.palette.mode === 'light'
+            ? `linear-gradient(180deg, ${alpha(theme.palette.background.paper, 0.99)} 0%, ${alpha(theme.palette.background.paper, 0.95)} 100%)`
+            : `linear-gradient(180deg, ${alpha(theme.palette.background.default, 0.96)} 0%, ${alpha(theme.palette.background.default, 0.88)} 100%)`,
+          boxShadow: isMobile ? theme.shadows[16] : theme.shadows[18],
+          backdropFilter: 'blur(18px)',
         }),
       }}
     >

--- a/src/components/search/UnifiedSearchBar.tsx
+++ b/src/components/search/UnifiedSearchBar.tsx
@@ -533,6 +533,7 @@ export const UnifiedSearchBar: React.FC<UnifiedSearchBarProps> = ({
   appearance = 'light',
 }) => {
   const [selectorOpen, setSelectorOpen] = useState(false);
+  const [selectorAnchorEl, setSelectorAnchorEl] = useState<HTMLElement | null>(null);
   const [internalRandomLoading, setInternalRandomLoading] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const shouldRestoreFocusRef = useRef(false);
@@ -564,20 +565,26 @@ export const UnifiedSearchBar: React.FC<UnifiedSearchBarProps> = ({
     return glyph;
   }, [currentLabel, currentSeries, currentValueId]);
 
-  const handleFilterClick = useCallback(() => {
+  const handleFilterClick = useCallback((anchor: HTMLElement) => {
     // open selector without forcing expansion
+    setSelectorAnchorEl(anchor);
     setSelectorOpen(true);
+  }, []);
+
+  const handleCloseSelector = useCallback(() => {
+    setSelectorOpen(false);
+    setSelectorAnchorEl(null);
   }, []);
 
   const handleSelect: OnSelectSeries = useCallback(
     (selectedId) => {
       onSelectSeries(selectedId);
-      setSelectorOpen(false);
+      handleCloseSelector();
       requestAnimationFrame(() => {
         inputRef.current?.focus();
       });
     },
-    [onSelectSeries],
+    [handleCloseSelector, onSelectSeries],
   );
 
   const handleClear = useCallback(() => {
@@ -645,9 +652,8 @@ export const UnifiedSearchBar: React.FC<UnifiedSearchBarProps> = ({
     ? `Choose series: ${currentLabel}`
     : `Show filter options for ${currentLabel}`;
 
-  const handleScopeClick = useCallback(() => {
-    // Always open selector; do not force expansion here
-    handleFilterClick();
+  const handleScopeClick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    handleFilterClick(event.currentTarget);
   }, [handleFilterClick]);
 
   return (
@@ -663,7 +669,7 @@ export const UnifiedSearchBar: React.FC<UnifiedSearchBarProps> = ({
               aria-expanded={scopeExpanded}
               aria-pressed={scopeExpanded}
               aria-label={scopeButtonLabel}
-              aria-haspopup="dialog"
+              aria-haspopup="listbox"
               title={currentLabel}
             >
               <ScopeGlyph>{scopeGlyph}</ScopeGlyph>
@@ -741,7 +747,7 @@ export const UnifiedSearchBar: React.FC<UnifiedSearchBarProps> = ({
               aria-expanded={scopeExpanded}
               aria-pressed={scopeExpanded}
               aria-label={scopeButtonLabel}
-              aria-haspopup="dialog"
+              aria-haspopup="listbox"
               title={currentLabel}
               className="railButton"
             >
@@ -780,12 +786,13 @@ export const UnifiedSearchBar: React.FC<UnifiedSearchBarProps> = ({
       </FieldShell>
       <SeriesSelectorDialog
         open={selectorOpen}
-        onClose={() => setSelectorOpen(false)}
+        onClose={handleCloseSelector}
         onSelect={handleSelect}
         shows={shows}
         savedCids={savedCids}
         currentValueId={currentValueId}
         includeAllFavorites={includeAllFavorites}
+        anchorEl={selectorAnchorEl}
       />
     </FormRoot>
   );


### PR DESCRIPTION
Improves the new selector by making it behave more like a dropdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Series selector now opens as a Popover anchored to the search scope button (mobile still uses a Dialog), with focus/scroll resets and minor styling/ARIA tweaks.
> 
> - **Frontend**
>   - **Series Selector (`src/components/SeriesSelectorDialog.tsx`)**
>     - Adds `anchorEl` prop and switches desktop rendering to MUI `Popover`; falls back to `Dialog` on mobile.
>     - Refactors layout into reusable `renderFilterInput` and `listContent`; adjusts max heights and origins per device.
>     - Improves open behavior: clears filter, scrolls to top, focuses input on desktop.
>     - Simplifies quick-picks visibility (based only on filter state) and tweaks item typography/spacing.
>   - **Unified Search Bar (`src/components/search/UnifiedSearchBar.tsx`)**
>     - Tracks and passes `selectorAnchorEl` to `SeriesSelectorDialog`; opens selector with button as anchor.
>     - Centralizes close handling, restores input focus after selection, and updates `aria-haspopup` to `listbox`.
> - **Meta**
>   - Bumps version to `2.16.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a064bc36c5c161b611a567c49a5ba27a737ad462. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->